### PR TITLE
Made default timeout for JUnit scenarios configurable

### DIFF
--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/JUnitScenarioRunner.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/JUnitScenarioRunner.kt
@@ -106,7 +106,10 @@ class JUnitScenarioRunner<
     >(private val testClass: Class<*>) : ParentRunner<ScenarioRun<AF, CF, QF, AGF>>(testClass) {
 
     companion object {
-        private val defaultTimeout = Timeout(3, TimeUnit.MINUTES)
+        const val junitTimeoutPropertyName = "com.anaplan.engineering.azuki.junit.timeout"
+
+        private val defaultTimeout =
+            Timeout(System.getProperty(junitTimeoutPropertyName).toLongOrNull() ?: 3, TimeUnit.MINUTES)
 
         private val Log = LoggerFactory.getLogger(JUnitScenarioRunner::class.java)
     }


### PR DESCRIPTION
N.B. 0 can be used to avoid timeout