### PR TITLE
Standardize core property names

### DIFF
--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/JvmSystemProperties.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/JvmSystemProperties.kt
@@ -1,0 +1,58 @@
+package com.anaplan.engineering.azuki.core
+
+object JvmSystemProperties {
+
+    /**
+     * Comma separated list of implementations to explicitly include when running scenarios
+     */
+    const val includedImplementationsPropertyName = "com.anaplan.engineering.azuki.implementation.includes"
+
+    /**
+     * Comma separated list of implementations to explicitly exclude when running scenarios
+     */
+    const val excludedImplementationsPropertyName = "com.anaplan.engineering.azuki.implementation.excludes"
+
+    /**
+     * Comma separated list of jar files containing implementation instances
+     *
+     * Used when classloading implementations dynamically
+     */
+    const val jarInstancesPropertyName = "com.anaplan.engineering.azuki.implementation.instance.jars"
+
+    /**
+     * If non-zero the default timeout in minutes to apply to scenarios run with JUnit
+     *
+     * Default: 3
+     */
+    const val junitTimeoutPropertyName = "com.anaplan.engineering.azuki.junit.timeout"
+
+    /**
+     * If true the implementation name will be excluded from the description of JUnit tests
+     *
+     * Default:false
+     *
+     * N.B. if using more than one implementation, setting this property to truw will cause
+     * JUnit report files from the same test, but with different implementations to overwrite
+     * each other
+     */
+    const val excludeImplFromEacDescriptionPropertyName = "com.anaplan.engineering.azuki.junit.excludeImplName"
+
+    /**
+     * If true JUnit scenarios annotated with KnownBug will be run rather than skipped
+     *
+     * Default: false
+     */
+    const val forceKnownBugsPropertyName = "com.anaplan.engineering.azuki.junit.runKnownBugs"
+
+    /**
+     * If true will redirect stdout & stderr to log
+     *
+     * Default: false
+     */
+    const val redirectStdStreamsPropertyName = "com.anaplan.engineering.azuki.task.redirectStdStreams"
+
+    /**
+     * If present Azuki will write EAC metadata to the specified directory
+     */
+    const val eacMetadataDirPropertyName = "com.anaplan.engineering.azuki.eac.metadataDir"
+}

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/ImplementationInstance.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/ImplementationInstance.kt
@@ -1,5 +1,8 @@
 package com.anaplan.engineering.azuki.core.runner
 
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.jarInstancesPropertyName
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.includedImplementationsPropertyName
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.excludedImplementationsPropertyName
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
 import com.anaplan.engineering.azuki.core.system.*
 import org.slf4j.LoggerFactory
@@ -33,9 +36,6 @@ interface ImplementationInstance<
     ): TaskResult<S, R>
 
     companion object {
-        const val includedImplementationsPropertyName = "com.anaplan.engineering.azuki.implementation.includes"
-        const val excludedImplementationsPropertyName = "com.anaplan.engineering.azuki.implementation.excludes"
-        const val jarInstancesPropertyName = "com.anaplan.engineering.azuki.implementation.instance.jars"
 
         private val Log = LoggerFactory.getLogger(JarImplementationInstance::class.java)
 

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/JUnitScenarioRunner.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/JUnitScenarioRunner.kt
@@ -1,5 +1,8 @@
 package com.anaplan.engineering.azuki.core.runner
 
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.excludeImplFromEacDescriptionPropertyName
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.forceKnownBugsPropertyName
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.junitTimeoutPropertyName
 import com.anaplan.engineering.azuki.core.scenario.VerifiableScenario
 import com.anaplan.engineering.azuki.core.system.*
 import org.junit.Assume
@@ -106,8 +109,6 @@ class JUnitScenarioRunner<
     >(private val testClass: Class<*>) : ParentRunner<ScenarioRun<AF, CF, QF, AGF>>(testClass) {
 
     companion object {
-        const val junitTimeoutPropertyName = "com.anaplan.engineering.azuki.junit.timeout"
-
         private val defaultTimeout =
             Timeout(System.getProperty(junitTimeoutPropertyName, "3").toLong(), TimeUnit.MINUTES)
 
@@ -115,7 +116,7 @@ class JUnitScenarioRunner<
     }
 
     private val runKnownBugs by lazy {
-        System.getProperty("run.known.bugs", "false").toBoolean()
+        System.getProperty(forceKnownBugsPropertyName, "false").toBoolean()
     }
 
     private val runMethod by lazy {
@@ -304,7 +305,7 @@ class JUnitScenarioRunner<
         }
 
     private val excludeImplFromDescription by lazy {
-        System.getProperty("excludeImplFromEacDescription", "true").toBoolean()
+        System.getProperty(excludeImplFromEacDescriptionPropertyName, "false").toBoolean()
     }
 
 }

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
@@ -1,5 +1,6 @@
 package com.anaplan.engineering.azuki.core.runner
 
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.redirectStdStreamsPropertyName
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
 import com.anaplan.engineering.azuki.core.system.*
 import org.slf4j.LoggerFactory
@@ -20,7 +21,7 @@ internal class TaskWrapper<
 
     fun <S : BuildableScenario<AF>> run(scenario: S): TaskResult<S, R> {
         val start = System.nanoTime()
-        val redirectStdStreams = System.getProperty(redirectStdStreamsPropertyName)?.toBoolean() == true
+        val redirectStdStreams = System.getProperty(redirectStdStreamsPropertyName, "false").toBoolean()
         val out = System.out
         val err = System.err
         val outCapture = LogAndCaptureOutputStream { if (redirectStdStreams) Log.info(it) else out.println(it) }
@@ -69,8 +70,6 @@ internal class TaskWrapper<
 
     companion object {
         private val Log = LoggerFactory.getLogger(TaskWrapper::class.java)
-
-        const val redirectStdStreamsPropertyName = "com.anaplan.engineering.azuki.task.redirectStdStreams"
 
         private fun Long.formatNs(): String =
             if (this > 10_000_000_000L) {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/system/EacMetadata.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/system/EacMetadata.kt
@@ -1,6 +1,7 @@
 package com.anaplan.engineering.azuki.core.system
 
 
+import com.anaplan.engineering.azuki.core.JvmSystemProperties.eacMetadataDirPropertyName
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import java.io.File
@@ -13,8 +14,6 @@ const val unsupportedBehavior: Behavior = -1
 interface ReifiedBehavior  {
     val behavior: Behavior
 }
-
-
 
 data class EacMetadata(
     val functionalElement: FunctionalElement,
@@ -29,14 +28,11 @@ data class EacMetadata(
 
 internal val objectMapper = ObjectMapper().registerModule(KotlinModule())
 
-internal const val eacMetadataDirProperty = "eac.metadata.dir"
-internal const val eacReportDirProperty = "eac.report.dir"
-
 object EacMetadataRecorder {
 
-    private val metadataDir by lazy { File(java.lang.System.getProperty(eacMetadataDirProperty)) }
+    private val metadataDir by lazy { File(java.lang.System.getProperty(eacMetadataDirPropertyName)) }
 
-    val recording by lazy { java.lang.System.getProperties().containsKey(eacMetadataDirProperty) }
+    val recording by lazy { java.lang.System.getProperties().containsKey(eacMetadataDirPropertyName) }
 
     fun record(metadata: EacMetadata) {
         val implDir = File(metadataDir, metadata.implementation)


### PR DESCRIPTION
+ restore inadvertent change to default for 'exclude impl name from junit description' property