### PR TITLE
Replace JSR233 script engine with Kotlin script host

### DIFF
--- a/azuki-core/build.gradle
+++ b/azuki-core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.semver4j:semver4j:5.2.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'
 
-    implementation 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
+    runtimeOnly 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
     implementation 'org.jetbrains.kotlin:kotlin-scripting-common'
     implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm'
     implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm-host'

--- a/azuki-core/build.gradle
+++ b/azuki-core/build.gradle
@@ -10,13 +10,10 @@ dependencies {
     implementation 'org.semver4j:semver4j:5.2.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'
 
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-script-runtime'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-scripting-common'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-scripting-jvm'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-scripting-dependencies'
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-scripting-jsr223'
+    implementation 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
+    implementation 'org.jetbrains.kotlin:kotlin-scripting-common'
+    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm'
+    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm-host'
 }
 
 publishing {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
@@ -3,7 +3,20 @@ package com.anaplan.engineering.azuki.core.parser
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
 
 interface ScenarioParser<S : BuildableScenario<*>> {
-
+    /**
+     * Parses a scenario from a string and additional imports prefix.
+     *
+     * New implementors of ScenarioParser should implement this by calling
+     * `parse(scenarioString) { requireImportsFromString(requiredImports) }`.
+     */
+    @Deprecated(
+        "Passing required imports as a string is deprecated and may disappear in a future major revision",
+        ReplaceWith(
+            "parse(scenarioString) { requireImportsFromString(requiredImports) }",
+            "com.anaplan.engineering.azuki.core.parser.ScenarioParser",
+            "com.anaplan.engineering.azuki.core.parser.ScenarioParsingContext"
+        )
+    )
     fun parse(
         scenarioString: String, requiredImports: String
     ): S
@@ -13,12 +26,16 @@ interface ScenarioParser<S : BuildableScenario<*>> {
      *
      * Supply extra implicit imports to include into the script as a lambda
      * expression following the scenario itself.
+     *
+     * New implementors of ScenarioParser should implement this method
+     * directly.
      */
     fun parse(
         scenarioString: String, init: ScenarioParsingContext.() -> Unit
     ): S {
         val requiredImports = ScenarioParsingContext().apply(init).toImportString()
 
+        @Suppress("DEPRECATION")
         return parse(scenarioString, requiredImports)
     }
 }

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
@@ -31,7 +31,7 @@ interface ScenarioParser<S : BuildableScenario<*>> {
      * directly.
      */
     fun parse(
-        scenarioString: String, initContext: ScenarioParsingContext.() -> Unit
+        scenarioString: String, initContext: ScenarioParsingContext.() -> Unit = {}
     ): S {
         val requiredImports = ScenarioParsingContext().apply(initContext).toImportString()
 

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
@@ -31,9 +31,9 @@ interface ScenarioParser<S : BuildableScenario<*>> {
      * directly.
      */
     fun parse(
-        scenarioString: String, init: ScenarioParsingContext.() -> Unit
+        scenarioString: String, initContext: ScenarioParsingContext.() -> Unit
     ): S {
-        val requiredImports = ScenarioParsingContext().apply(init).toImportString()
+        val requiredImports = ScenarioParsingContext().apply(initContext).toImportString()
 
         @Suppress("DEPRECATION")
         return parse(scenarioString, requiredImports)

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
@@ -2,11 +2,47 @@ package com.anaplan.engineering.azuki.core.parser
 
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
 
-interface ScenarioParser<S: BuildableScenario<*>> {
+interface ScenarioParser<S : BuildableScenario<*>> {
 
     fun parse(
-        scenarioString: String,
-        requiredImports: String
+        scenarioString: String, requiredImports: String
     ): S
 
+    /**
+     * Parses a scenario from a string.
+     *
+     * Supply extra context, such as implicit imports to include into the
+     * script, as a lambda expression following the
+     */
+    fun parse(
+        scenarioString: String, init: ScenarioParsingContext.() -> Unit
+    ): S {
+        val requiredImports = ScenarioParsingContext().apply(init).toImportString()
+
+        return parse(scenarioString, requiredImports)
+    }
+}
+
+class ScenarioParsingContext(private val requiredImports: MutableList<String> = mutableListOf()) {
+    val imports: List<String> get() = requiredImports
+
+    /**
+     * Parses a block of top-level imports and adds them to the context.
+     */
+    fun requireImportsFromString(string: String) {
+        val toAdd = string.split("\n").map {
+            it.trim().removePrefix("import").trim()
+        }.filter { it.isNotBlank() }
+
+        requiredImports.addAll(toAdd)
+    }
+
+    /**
+     * Adds one or more imports to the script before parsing it.
+     */
+    fun import(vararg imports: String) {
+        requiredImports.addAll(imports)
+    }
+
+    fun toImportString(): String = requiredImports.joinToString("\n") { "import $it" }
 }

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/ScenarioParser.kt
@@ -11,8 +11,8 @@ interface ScenarioParser<S : BuildableScenario<*>> {
     /**
      * Parses a scenario from a string.
      *
-     * Supply extra context, such as implicit imports to include into the
-     * script, as a lambda expression following the
+     * Supply extra implicit imports to include into the script as a lambda
+     * expression following the scenario itself.
      */
     fun parse(
         scenarioString: String, init: ScenarioParsingContext.() -> Unit
@@ -26,9 +26,6 @@ interface ScenarioParser<S : BuildableScenario<*>> {
 class ScenarioParsingContext(private val requiredImports: MutableList<String> = mutableListOf()) {
     val imports: List<String> get() = requiredImports
 
-    /**
-     * Parses a block of top-level imports and adds them to the context.
-     */
     fun requireImportsFromString(string: String) {
         val toAdd = string.split("\n").map {
             it.trim().removePrefix("import").trim()
@@ -37,9 +34,6 @@ class ScenarioParsingContext(private val requiredImports: MutableList<String> = 
         requiredImports.addAll(toAdd)
     }
 
-    /**
-     * Adds one or more imports to the script before parsing it.
-     */
     fun import(vararg imports: String) {
         requiredImports.addAll(imports)
     }

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -2,37 +2,71 @@ package com.anaplan.engineering.azuki.core.parser
 
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
 import java.util.concurrent.locks.ReentrantLock
-import javax.script.ScriptEngineManager
+import kotlin.reflect.KClass
+import kotlin.script.experimental.annotations.KotlinScript
+import kotlin.script.experimental.api.ResultValue
+import kotlin.script.experimental.api.ScriptCompilationConfiguration
+import kotlin.script.experimental.api.defaultImports
+import kotlin.script.experimental.api.valueOrThrow
+import kotlin.script.experimental.host.toScriptSource
+import kotlin.script.experimental.jvm.dependenciesFromCurrentContext
+import kotlin.script.experimental.jvm.jvm
+import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
 
-class SimpleScenarioParser<S: BuildableScenario<*>>: ScenarioParser<S> {
+class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
 
     private val engine by lazy {
-        ScriptEngineManager().getEngineByExtension("kts")
+        BasicJvmScriptingHost()
     }
 
     private val lock = ReentrantLock()
 
     override fun parse(
-        scenarioString: String,
-        requiredImports: String
-    ): S {
-        val script = """
-            $requiredImports
+        scenarioString: String, requiredImports: String
+    ): S = parse(scenarioString, requiredImportLines = requiredImports.split("\n").map {
+        it.trim().removePrefix("import").trim()
+    }.filter { it.isNotBlank() }.toList())
 
-            $scenarioString
-        """
-        // KotlinJsr223JvmLocalScriptEngine is not thread safe
+    fun parse(
+        scenarioString: String,
+        requiredImportLines: List<String> = listOf(),
+        requiredImportClasses: List<KClass<*>> = listOf(),
+    ): S {
+        val script = scenarioString.toScriptSource()
+
+        // TODO: do we need this lock for the Kotlin host?
         val evalResult = try {
             lock.lock()
-            engine.eval(script)
+            engine.evalWithTemplate<SimpleScenario>(script, {
+                defaultImports(requiredImportLines)
+                defaultImports(*requiredImportClasses.toTypedArray())
+            })
         } finally {
             lock.unlock()
         }
-        if (evalResult !is BuildableScenario<*>) {
+
+        val returnValue = evalResult.valueOrThrow().returnValue
+        if (returnValue !is ResultValue.Value) {
+            throw IllegalArgumentException("Script did not return a value")
+        }
+
+        val scenario = returnValue.value
+        if (scenario !is BuildableScenario<*>) {
             throw IllegalArgumentException("Script does not evaluate to scenario")
         }
-        @Suppress("UNCHECKED_CAST")
-        return evalResult as S
+        @Suppress("UNCHECKED_CAST") return scenario as S
     }
 
+}
+
+@KotlinScript(fileExtension = "scn.kts", compilationConfiguration = SimpleScenarioCompilationConfiguration::class)
+abstract class SimpleScenario
+
+object SimpleScenarioCompilationConfiguration : ScriptCompilationConfiguration({
+    jvm {
+        // Extract the whole classpath from context classloader and use it as dependencies
+        dependenciesFromCurrentContext(wholeClasspath = true)
+    }
+}) {
+    private fun readResolve(): Any = SimpleScenarioCompilationConfiguration
 }

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -20,6 +20,10 @@ class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
 
     private val lock = ReentrantLock()
 
+    @Deprecated("Passing required imports as a string is deprecated and may disappear in a future major revision",
+        replaceWith = ReplaceWith("parse(scenarioString) { requireImportsFromString(requiredImports) }",
+            "com.anaplan.engineering.azuki.core.parser.ScenarioParser",
+            "com.anaplan.engineering.azuki.core.parser.ScenarioParsingContext"))
     override fun parse(
         scenarioString: String, requiredImports: String
     ): S = parse(scenarioString) {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -57,7 +57,7 @@ class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
 
 }
 
-@KotlinScript(fileExtension = "scn.kts", compilationConfiguration = SimpleScenarioCompilationConfiguration::class)
+@KotlinScript(fileExtension = "scn", compilationConfiguration = SimpleScenarioCompilationConfiguration::class)
 abstract class SimpleScenario
 
 object SimpleScenarioCompilationConfiguration : ScriptCompilationConfiguration({

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -2,7 +2,6 @@ package com.anaplan.engineering.azuki.core.parser
 
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
 import java.util.concurrent.locks.ReentrantLock
-import kotlin.reflect.KClass
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ResultValue
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
@@ -23,23 +22,22 @@ class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
 
     override fun parse(
         scenarioString: String, requiredImports: String
-    ): S = parse(scenarioString, requiredImportLines = requiredImports.split("\n").map {
-        it.trim().removePrefix("import").trim()
-    }.filter { it.isNotBlank() }.toList())
+    ): S = parse(scenarioString) {
+        requireImportsFromString(requiredImports)
+    }
 
-    fun parse(
+    override fun parse(
         scenarioString: String,
-        requiredImportLines: List<String> = listOf(),
-        requiredImportClasses: List<KClass<*>> = listOf(),
+        init: ScenarioParsingContext.() -> Unit
     ): S {
         val script = scenarioString.toScriptSource()
+        val context = ScenarioParsingContext().apply(init)
 
         // TODO: do we need this lock for the Kotlin host?
         val evalResult = try {
             lock.lock()
             engine.evalWithTemplate<SimpleScenario>(script, {
-                defaultImports(requiredImportLines)
-                defaultImports(*requiredImportClasses.toTypedArray())
+                defaultImports(context.imports)
             })
         } finally {
             lock.unlock()

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -19,6 +19,11 @@ open class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
 
     private val lock = ReentrantLock()
 
+    /**
+     * Imports that are pulled into every scenario in addition to those specified in the call to `parse`.
+     */
+    protected open val defaultImports: ScenarioParsingContext.() -> Unit = {}
+
     @Deprecated("Passing required imports as a string is deprecated and may disappear in a future major revision",
         replaceWith = ReplaceWith("parse(scenarioString) { requireImportsFromString(requiredImports) }",
             "com.anaplan.engineering.azuki.core.parser.ScenarioParser",
@@ -29,12 +34,12 @@ open class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
         requireImportsFromString(requiredImports)
     }
 
-    override fun parse(
+    final override fun parse(
         scenarioString: String,
         initContext: ScenarioParsingContext.() -> Unit
     ): S {
         val script = scenarioString.toScriptSource()
-        val scenarioContext = ScenarioParsingContext().apply(initContext)
+        val scenarioContext = ScenarioParsingContext().apply(defaultImports).apply(initContext)
 
         // TODO: do we need this lock for the Kotlin host?
         val evalResult = try {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -43,16 +43,12 @@ class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
             lock.unlock()
         }
 
-        val returnValue = evalResult.valueOrThrow().returnValue
-        if (returnValue !is ResultValue.Value) {
-            throw IllegalArgumentException("Script did not return a value")
+        val result = evalResult.valueOrThrow().returnValue
+        if (result !is ResultValue.Value || result.value !is BuildableScenario<*>) {
+            throw IllegalArgumentException("Script does not evaluate to scenario (got $result)")
         }
 
-        val scenario = returnValue.value
-        if (scenario !is BuildableScenario<*>) {
-            throw IllegalArgumentException("Script does not evaluate to scenario")
-        }
-        @Suppress("UNCHECKED_CAST") return scenario as S
+        @Suppress("UNCHECKED_CAST") return result.value as S
     }
 
 }

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -12,9 +12,7 @@ import kotlin.script.experimental.jvm.dependenciesFromCurrentContext
 import kotlin.script.experimental.jvm.jvm
 import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
 
-class SimpleScenarioParser<S : BuildableScenario<*>>(initContext: ScenarioParsingContext.() -> Unit = {}) : ScenarioParser<S> {
-    private val commonContext = ScenarioParsingContext().apply(initContext)
-
+open class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
     private val engine by lazy {
         BasicJvmScriptingHost()
     }
@@ -25,7 +23,7 @@ class SimpleScenarioParser<S : BuildableScenario<*>>(initContext: ScenarioParsin
         replaceWith = ReplaceWith("parse(scenarioString) { requireImportsFromString(requiredImports) }",
             "com.anaplan.engineering.azuki.core.parser.ScenarioParser",
             "com.anaplan.engineering.azuki.core.parser.ScenarioParsingContext"))
-    override fun parse(
+    final override fun parse(
         scenarioString: String, requiredImports: String
     ): S = parse(scenarioString) {
         requireImportsFromString(requiredImports)
@@ -42,7 +40,6 @@ class SimpleScenarioParser<S : BuildableScenario<*>>(initContext: ScenarioParsin
         val evalResult = try {
             lock.lock()
             engine.evalWithTemplate<SimpleScenario>(script, {
-                defaultImports(commonContext.imports)
                 defaultImports(scenarioContext.imports)
             })
         } finally {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -12,7 +12,8 @@ import kotlin.script.experimental.jvm.dependenciesFromCurrentContext
 import kotlin.script.experimental.jvm.jvm
 import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
 
-class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
+class SimpleScenarioParser<S : BuildableScenario<*>>(initContext: ScenarioParsingContext.() -> Unit = {}) : ScenarioParser<S> {
+    private val commonContext = ScenarioParsingContext().apply(initContext)
 
     private val engine by lazy {
         BasicJvmScriptingHost()
@@ -32,16 +33,17 @@ class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
 
     override fun parse(
         scenarioString: String,
-        init: ScenarioParsingContext.() -> Unit
+        initContext: ScenarioParsingContext.() -> Unit
     ): S {
         val script = scenarioString.toScriptSource()
-        val context = ScenarioParsingContext().apply(init)
+        val scenarioContext = ScenarioParsingContext().apply(initContext)
 
         // TODO: do we need this lock for the Kotlin host?
         val evalResult = try {
             lock.lock()
             engine.evalWithTemplate<SimpleScenario>(script, {
-                defaultImports(context.imports)
+                defaultImports(commonContext.imports)
+                defaultImports(scenarioContext.imports)
             })
         } finally {
             lock.unlock()

--- a/azuki-runner/src/main/kotlin/com/anaplan/engineering/azuki/runner/ScenarioScriptRunner.kt
+++ b/azuki-runner/src/main/kotlin/com/anaplan/engineering/azuki/runner/ScenarioScriptRunner.kt
@@ -14,7 +14,6 @@ import com.anaplan.engineering.azuki.core.system.QueryFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
-import javax.script.ScriptException
 import kotlin.reflect.KClass
 import kotlin.system.exitProcess
 
@@ -92,8 +91,10 @@ class ScenarioScriptRunner<
     fun runScenario(scenarioScript: String) {
         try {
             val scenario = try {
-                SimpleScenarioParser<BuildableScenario<AF>>().parse(scenarioScript, scenarioImports)
-            } catch (e: ScriptException) {
+                SimpleScenarioParser<BuildableScenario<AF>>().parse(scenarioScript) {
+                    requireImportsFromString(scenarioImports)
+                }
+            } catch (e: RuntimeException) {
                 resultProcessor.handleError(InvalidScenarioException(e))
                 return
             }
@@ -155,7 +156,7 @@ class ScenarioScriptRunner<
         }
     }
 
-    class InvalidScenarioException(e: ScriptException) : RuntimeException(e)
+    class InvalidScenarioException(e: RuntimeException) : RuntimeException(e)
     class UnsupportedScenarioTypeException(val type: KClass<*>) : RuntimeException()
 }
 

--- a/azuki-verify/azuki-batch-guided/src/main/kotlin/com/anaplan/engineering/azuki/verify/batch/guided/GuidedScenarioBatch.kt
+++ b/azuki-verify/azuki-batch-guided/src/main/kotlin/com/anaplan/engineering/azuki/verify/batch/guided/GuidedScenarioBatch.kt
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.File
 import java.util.*
-import javax.script.ScriptException
 
 class GuidedScenarioBatch<S : BuildableScenario<*>, RC : ScenarioResultContext>:
     OrchestratableScenarioBatch<GuidedScenario, RC> {
@@ -51,8 +50,8 @@ class GuidedScenarioBatch<S : BuildableScenario<*>, RC : ScenarioResultContext>:
     private fun checkAllBaseScenariosCanBeParsed() {
         batchState.baseScenarios.forEach {
             try {
-                scenarioParser.parse(it.readText(), "")
-            } catch (e: ScriptException) {
+                scenarioParser.parse(it.readText()) {}
+            } catch (e: RuntimeException) {
                 throw IllegalStateException("Scenario in file ${it.absolutePath} is invalid", e)
             }
         }

--- a/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/ScenarioScriptingTestUtils.kt
+++ b/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/ScenarioScriptingTestUtils.kt
@@ -24,11 +24,10 @@ object ScenarioScriptingTestUtils {
         Log.debug("Generated:\n$generatedScript")
 
         val parsedScenario = SimpleScenarioParser<GraphBuildableScenario>().parse(
-            generatedScript,
-            requiredImportLines = listOf(
-                "com.anaplan.engineering.azuki.graphs.dsl.*",
-            ),
-        )
+            generatedScript
+        ) {
+            import("com.anaplan.engineering.azuki.graphs.dsl.*")
+        }
 
         Log.debug("Regenerating script")
         val regeneratedScript = GraphScriptGenerator.generateScript(parsedScenario)

--- a/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/ScenarioScriptingTestUtils.kt
+++ b/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/ScenarioScriptingTestUtils.kt
@@ -2,7 +2,6 @@ package com.anaplan.engineering.azuki.graphs.adapter.scriptgen
 
 import com.anaplan.engineering.azuki.core.parser.SimpleScenarioParser
 import com.anaplan.engineering.azuki.graphs.dsl.GraphBuildableScenario
-import com.anaplan.engineering.azuki.graphs.dsl.GraphScenario
 import org.junit.Assert
 import org.slf4j.LoggerFactory
 
@@ -24,10 +23,12 @@ object ScenarioScriptingTestUtils {
         val generatedScript = GraphScriptGenerator.generateScript(scenario)
         Log.debug("Generated:\n$generatedScript")
 
-        val parsedScenario = SimpleScenarioParser<GraphBuildableScenario>().parse(generatedScript, """
-            import com.anaplan.engineering.azuki.graphs.dsl.*
-            import com.anaplan.engineering.azuki.graphs.*
-        """)
+        val parsedScenario = SimpleScenarioParser<GraphBuildableScenario>().parse(
+            generatedScript,
+            requiredImportLines = listOf(
+                "com.anaplan.engineering.azuki.graphs.dsl.*",
+            ),
+        )
 
         Log.debug("Regenerating script")
         val regeneratedScript = GraphScriptGenerator.generateScript(parsedScenario)

--- a/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/ScenarioScriptingTestUtils.kt
+++ b/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/ScenarioScriptingTestUtils.kt
@@ -27,6 +27,7 @@ object ScenarioScriptingTestUtils {
             generatedScript
         ) {
             import("com.anaplan.engineering.azuki.graphs.dsl.*")
+            import("com.anaplan.engineering.azuki.graphs.*")
         }
 
         Log.debug("Regenerating script")


### PR DESCRIPTION
This PR swaps out the implementation of `ScenarioParser` to use the [Kotlin JVM custom scripting API](https://kotlinlang.org/docs/custom-script-deps-tutorial.html#project-structure).  It removes dependency on the JSR233 implementation for Kotlin scripting, which is [earmarked to go away in a couple of Kotlin versions anyway](https://blog.jetbrains.com/kotlin/2024/11/state-of-kotlin-scripting-2024/).

Doing this was originally intended to help unblock a regression caused when I tried to migrate KtLint to a more modern version, but I've floated it into a separate PR because it's sufficiently standalone.  Compared to Jsr233, it seems more stable in certain cases, allows proper support of implicit includes, and provides a bit more room for tuning things like classpath, error reporting, etc. in an idiomatic way.

In a separate commit, which will likely need a bit more work, I've tried to come up with a slightly nicer API going forwards for using `ScenarioParser`.  Downstream code already depends on the existing interface, so I've had to implement it in a somewhat awkward way (unless it would be better to just make a new interface and abandon this one?).

Caveats:

- I'm not sure I've got the change to `ScenarioParser` right.  I want to avoid needing to scrape out import statements into a list if we don't need to, and one of the advantages of this engine is we _don't_ need to.  But the existing API is somewhat grandfathered in now.
- The custom scripting API is marked as experimental (with no obvious plans by JetBrains to adopt it - arguably, the opposite, but at least it's not slated for removal like Jsr233), so we definitely want to not expose too much of it downstream.
- The scripting API (and, indeed, the Jsr233 version) is very sensitive to other bits of the Kotlin compiler infrastructure with a different Kotlin version turning up in classpath.  I've noticed this in particular when upgrading KtLint, meaning that if we do both we'll have to be conservative with keeping both in lockstep on ~Kotlin2.0.
- I don't know if this script host is threadsafe, so I've conservatively kept the lock in place.