### PR TITLE
Added more specific error messages for bad script parsing values

### DIFF
--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -53,18 +53,29 @@ open class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
         }
 
         when (val result = evalResult.valueOrThrow().returnValue) {
-            is ResultValue.Unit ->
+            is ResultValue.Unit -> {
+                Log.error("Unit returned by the following script:\n\n{}", scenarioString)
+
                 throw IllegalArgumentException("Script does not evaluate to scenario: it returned nothing")
+            }
             is ResultValue.Error -> {
+                Log.error("Exception thrown in the following script:\n\n{}", scenarioString)
+
                 throw IllegalArgumentException("Script threw an exception while evaluating: $result", result.error)
             }
             else -> {
                 if (result !is ResultValue.Value || result.value !is BuildableScenario<*>) {
+                    Log.error("Non-scenario value returned by the following script:\n\n{}", scenarioString)
+
                     throw IllegalArgumentException("Script does not evaluate to scenario: got $result")
                 }
                 @Suppress("UNCHECKED_CAST") return result.value as S
             }
         }
+    }
+
+    companion object {
+        val Log = LoggerFactory.getLogger(SimpleScenarioParser::class.java)
     }
 }
 

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/parser/SimpleScenarioParser.kt
@@ -1,6 +1,7 @@
 package com.anaplan.engineering.azuki.core.parser
 
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
+import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ResultValue
@@ -51,14 +52,20 @@ open class SimpleScenarioParser<S : BuildableScenario<*>> : ScenarioParser<S> {
             lock.unlock()
         }
 
-        val result = evalResult.valueOrThrow().returnValue
-        if (result !is ResultValue.Value || result.value !is BuildableScenario<*>) {
-            throw IllegalArgumentException("Script does not evaluate to scenario (got $result)")
+        when (val result = evalResult.valueOrThrow().returnValue) {
+            is ResultValue.Unit ->
+                throw IllegalArgumentException("Script does not evaluate to scenario: it returned nothing")
+            is ResultValue.Error -> {
+                throw IllegalArgumentException("Script threw an exception while evaluating: $result", result.error)
+            }
+            else -> {
+                if (result !is ResultValue.Value || result.value !is BuildableScenario<*>) {
+                    throw IllegalArgumentException("Script does not evaluate to scenario: got $result")
+                }
+                @Suppress("UNCHECKED_CAST") return result.value as S
+            }
         }
-
-        @Suppress("UNCHECKED_CAST") return result.value as S
     }
-
 }
 
 @KotlinScript(fileExtension = "scn", compilationConfiguration = SimpleScenarioCompilationConfiguration::class)


### PR DESCRIPTION
This PR tries to fix up some ambiguous/misleading error reporting when a parsed scenario script raises an exception or doesn't return a value.  It:

- specifically calls out that the script threw if the result is `ResultValue.Error` instead of misleadingly claiming it returned an exception value
- handles unit separately
- tries to stuff any throwables into the cause section of the `IllegalArgumentException`, which should _hopefully_ produce a better stacktrace on failure.

I've manually tested the three different cases and they seem ok.