### PR TITLE
Add fallible version of composer registration

### DIFF
--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -37,9 +37,9 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
     /**
      * Gets the composer for a key, provided that it hasn't been removed through failure.
      */
-    operator fun get(key: K): S? = map[key]?.inner?.getOrNull()
+    operator fun get(key: K): S? = map[key]?.composer
 
-    val composers get() = map.values.map { it.inner }
+    val composers get() = map.values.mapNotNull { it.composer }
 }
 
 /**
@@ -47,20 +47,21 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
  */
 class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E> {
 
-    var inner = Result.success(initial)
+    private var _inner = Result.success(initial)
+    val composer: S? = _inner.getOrNull()
 
     /**
      * Registers a check on the inner composer by applying an effect to it.
      * If the effect returns a new object, this wrapper updates to point to it.
      */
-    fun register(effect: S.() -> S) = apply { inner = inner.map(effect) }
+    fun register(effect: S.() -> S) = apply { _inner = _inner.map(effect) }
 
     /**
      * As with register(), but can fail, permanently halting composition.
      */
-    fun tryRegister(effect: S.() -> Result<S>) = apply { inner = bind(effect) }
+    fun tryRegister(effect: S.() -> Result<S>) = apply { _inner = bind(effect) }
 
     override fun compose(environment: E): Result<List<ScriptGenerationCheck<E>>> = bind { compose(environment) }
 
-    private fun <T> bind(fn: S.() -> Result<T>) = inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
+    private fun <T> bind(fn: S.() -> Result<T>) = _inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
 }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -22,13 +22,22 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
     private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
 
     /**
-     * Registers a check for composition under the check state addressed by the given key.
-     * Applies the given transformation to the check state to capture the knowledge added from the check.
+     * Registers a check for composition inside this map, under the given key and with the given effect.
+     * If an existing composer exists under the same key, the effect is applied cumulatively to it.
      */
-    fun register(key: K, effect: S.() -> S): CheckComposer<E> =
-        map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }.register(effect)
+    fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)
 
-    operator fun get(key: K): S? = map[key]?.inner
+    /**
+     * As with register(), but can fail, permanently halting composition for this key
+     */
+    fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = getOrInit(key).tryRegister(effect)
+
+    private fun getOrInit(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
+
+    /**
+     * Gets the composer for a key, provided that it hasn't been removed through failure.
+     */
+    operator fun get(key: K): S? = map[key]?.inner?.getOrNull()
 
     val composers get() = map.values.map { it.inner }
 }
@@ -36,8 +45,22 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
 /**
  * Wraps a composer to ensure that effects that replace it with another object propagate correctly to the generator.
  */
-class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(var inner: S) : CheckComposer<E> {
+class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E> {
 
-    fun register(effect: S.() -> S) = apply { inner = inner.effect() }
-    override fun compose(environment: E): Result<List<ScriptGenerationCheck<E>>> = inner.compose(environment)
+    var inner = Result.success(initial)
+
+    /**
+     * Registers a check on the inner composer by applying an effect to it.
+     * If the effect returns a new object, this wrapper updates to point to it.
+     */
+    fun register(effect: S.() -> S) = apply { inner = inner.map(effect) }
+
+    /**
+     * As with register(), but can fail, permanently halting composition.
+     */
+    fun tryRegister(effect: S.() -> Result<S>) = apply { inner = bind(effect) }
+
+    override fun compose(environment: E): Result<List<ScriptGenerationCheck<E>>> = bind { compose(environment) }
+
+    private fun <T> bind(fn: S.() -> Result<T>) = inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
 }

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
@@ -1,9 +1,8 @@
 package com.anaplan.engineering.azuki.script.generation
 
-import kotlin.test.Test
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
-import kotlin.test.expect
+import com.anaplan.engineering.azuki.core.system.Behavior
+import com.anaplan.engineering.azuki.core.system.unsupportedBehavior
+import kotlin.test.*
 
 class CheckComposerTest {
 
@@ -25,9 +24,18 @@ class CheckComposerTest {
     fun mapRegisterUpdatesMapOnObjectChange() {
         val map = CheckComposerMap(Example::new)
         map.register("a") { increment() }
-        assertIs<Success>(map["a"])
-        map.register("a") { fail() }
-        assertIs<Fail>(map["a"])
+        assertIs<Forwards>(map["a"])
+        map.register("a") { reverse() }
+        assertIs<Backwards>(map["a"])
+    }
+
+    @Test
+    fun mapRegisterRemovesFromMapOnFailure() {
+        val map = CheckComposerMap(Example::new)
+        map.register("a") { increment() }
+        assertIs<Forwards>(map["a"])
+        map.tryRegister("a") { Result.failure(IllegalStateException("oops")) }
+        assertNull(map["a"], "a should now appear to have been removed")
     }
 
     @Test
@@ -35,10 +43,19 @@ class CheckComposerTest {
         val map = CheckComposerMap(Example::new)
         val env = NoScriptGenerationEnvironment
         val composerA = map.register("a") { increment() }
-        assertTrue("first composer should initially succeed") { composerA.compose(env).isSuccess }
-        val composerB = map.register("a") { fail() }
-        assertTrue("second composer should fail") { composerB.compose(env).isFailure }
-        assertTrue("first composer should now also fail" ) { composerA.compose(env).isFailure }
+        expect("forwards(1)") { composerA.compose(env).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment) }
+        val composerB = map.register("a") { reverse() }
+        listOf(composerA, composerB).forEach { c ->
+            expect("backwards(0)") { c.compose(env).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment) }
+        }
+        val composerC = map.register("a") { increment() }
+        listOf(composerA, composerB, composerC).forEach { c ->
+            expect("backwards(-1)") { c.compose(env).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment) }
+        }
+        val composerD = map.tryRegister("a") { fail() }
+        listOf(composerA, composerB, composerC, composerD).forEach { c ->
+            assertIs<IllegalStateException>(c.compose(env).exceptionOrNull())
+        }
     }
 
     @Test
@@ -50,46 +67,67 @@ class CheckComposerTest {
         wrapper.register { increment() }
         wrapper.register { increment() }
         wrapper.register { increment() }
-        expect(original, "should be wrapping the same object") { wrapper.inner }
-        expect(5, "should have mutated the same object") { wrapper.inner.counter }
+        val inner = wrapper.inner.getOrThrow()
+        expect(original, "should be wrapping the same object") { inner }
+        expect(5, "should have mutated the same object") { inner.counter }
     }
 
     @Test
     fun wrapperPropagatesComposerObjectChanges() {
         val original = Example.new("a")
         val wrapper = CheckComposerWrapper(original)
-        expect(original, "should have stored the original object") { wrapper.inner }
-        wrapper.register { fail() }
-        assertIs<Fail>(wrapper.inner, "should have changed the inner object")
+        expect(original, "should have stored the original object") { wrapper.inner.getOrThrow() }
+        wrapper.register { reverse() }
+        assertIs<Backwards>(wrapper.inner.getOrThrow(), "should have changed the inner object")
     }
 
-    interface Example : CheckComposer<NoScriptGenerationEnvironment> {
+    @Test
+    fun wrapperPropagatesComposerFailures() {
+        val original = Example.new("a")
+        val wrapper = CheckComposerWrapper(original)
+        expect(original, "should have stored the original object") { wrapper.inner.getOrThrow() }
+        wrapper.tryRegister { Result.failure(IllegalStateException("oops")) }
+        assertIs<IllegalStateException>(wrapper.inner.exceptionOrNull(), "should have changed the inner object")
+    }
 
-        val counter : Int?
-        fun increment(): Example
-        fun fail(): Example
+    abstract class Example(val name: String) : CheckComposer<NoScriptGenerationEnvironment> {
+
+        abstract val counter: Int?
+        abstract fun increment(): Example
+        abstract fun reverse(): Example
+        fun fail(): Result<Example> = Result.failure(IllegalStateException("oops"))
 
         companion object {
 
-            fun new(name: String) : Example = Success(name)
+            fun new(name: String): Example = Forwards(name)
         }
     }
 
-    class Success(val name: String) : Example {
+    class Forwards(name: String) : Example(name) {
 
         override var counter = 0
         override fun increment() = apply { counter++ }
-        override fun fail() = Fail
+        override fun reverse() = Backwards(name)
         override fun compose(environment: NoScriptGenerationEnvironment) =
-            Result.success<List<ScriptGenerationCheck<NoScriptGenerationEnvironment>>>(emptyList())
+            Result.success<List<ScriptGenerationCheck<NoScriptGenerationEnvironment>>>(listOf(object :
+                ScriptGenerationCheck<NoScriptGenerationEnvironment> {
+
+                override val behavior = unsupportedBehavior
+                override fun getCheckScript(environment: NoScriptGenerationEnvironment) = "forwards($counter)"
+            }))
     }
 
-    object Fail : Example {
+    class Backwards(name: String) : Example(name) {
 
-        override val counter = null
-        override fun increment() = this
-        override fun fail() = this
+        override var counter = 0
+        override fun increment() = apply { counter-- }
+        override fun reverse() = Forwards(name)
         override fun compose(environment: NoScriptGenerationEnvironment) =
-            Result.failure<List<ScriptGenerationCheck<NoScriptGenerationEnvironment>>>(IllegalStateException("failed"))
+            Result.success<List<ScriptGenerationCheck<NoScriptGenerationEnvironment>>>(listOf(object :
+                ScriptGenerationCheck<NoScriptGenerationEnvironment> {
+
+                override val behavior = unsupportedBehavior
+                override fun getCheckScript(environment: NoScriptGenerationEnvironment) = "backwards($counter)"
+            }))
     }
 }

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
@@ -41,20 +41,15 @@ class CheckComposerTest {
     @Test
     fun mapPropagatesComposerObjectChanges() {
         val map = CheckComposerMap(Example::new)
-        val env = NoScriptGenerationEnvironment
         val composerA = map.register("a") { increment() }
-        expect("forwards(1)") { composerA.compose(env).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment) }
+        expect("forwards(1)") { composerA.toScript() }
         val composerB = map.register("a") { reverse() }
-        listOf(composerA, composerB).forEach { c ->
-            expect("backwards(0)") { c.compose(env).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment) }
-        }
+        listOf(composerA, composerB).forEach { c -> expect("backwards(0)") { c.toScript() } }
         val composerC = map.register("a") { increment() }
-        listOf(composerA, composerB, composerC).forEach { c ->
-            expect("backwards(-1)") { c.compose(env).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment) }
-        }
+        listOf(composerA, composerB, composerC).forEach { c -> expect("backwards(-1)") { c.toScript() } }
         val composerD = map.tryRegister("a") { fail() }
         listOf(composerA, composerB, composerC, composerD).forEach { c ->
-            assertIs<IllegalStateException>(c.compose(env).exceptionOrNull())
+            assertIs<IllegalStateException>(c.compose(NoScriptGenerationEnvironment).exceptionOrNull())
         }
     }
 
@@ -62,32 +57,32 @@ class CheckComposerTest {
     fun wrapperRegisterReusesSameComposer() {
         val original = Example.new("a")
         val wrapper = CheckComposerWrapper(original)
+        expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
         wrapper.register { increment() }
         wrapper.register { increment() }
         wrapper.register { increment() }
         wrapper.register { increment() }
         wrapper.register { increment() }
-        val inner = wrapper.inner.getOrThrow()
-        expect(original, "should be wrapping the same object") { inner }
-        expect(5, "should have mutated the same object") { inner.counter }
+        expect("forwards(5)", "should have mutated the same object") { wrapper.toScript() }
     }
 
     @Test
     fun wrapperPropagatesComposerObjectChanges() {
         val original = Example.new("a")
         val wrapper = CheckComposerWrapper(original)
-        expect(original, "should have stored the original object") { wrapper.inner.getOrThrow() }
+        expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
         wrapper.register { reverse() }
-        assertIs<Backwards>(wrapper.inner.getOrThrow(), "should have changed the inner object")
+        expect("backwards(0)", "should have changed the inner object") { wrapper.toScript() }
     }
 
     @Test
     fun wrapperPropagatesComposerFailures() {
         val original = Example.new("a")
         val wrapper = CheckComposerWrapper(original)
-        expect(original, "should have stored the original object") { wrapper.inner.getOrThrow() }
+        expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
         wrapper.tryRegister { Result.failure(IllegalStateException("oops")) }
-        assertIs<IllegalStateException>(wrapper.inner.exceptionOrNull(), "should have changed the inner object")
+        assertIs<IllegalStateException>(wrapper.compose(NoScriptGenerationEnvironment).exceptionOrNull(),
+            "should have changed the inner object")
     }
 
     abstract class Example(val name: String) : CheckComposer<NoScriptGenerationEnvironment> {
@@ -131,3 +126,6 @@ class CheckComposerTest {
             }))
     }
 }
+
+private fun CheckComposer<NoScriptGenerationEnvironment>.toScript() =
+    compose(NoScriptGenerationEnvironment).getOrThrow()[0].getCheckScript(NoScriptGenerationEnvironment)

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationCheckFactory.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationCheckFactory.kt
@@ -26,13 +26,13 @@ object GameScriptGenerationCheckFactory : GameCheckFactory {
     override fun hasToken(gameName: String, playerName: String, position: Position) = TicTacToeScriptGenerationCheck {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::boardHasToken, gameName, playerName, position)
     }.asComposable {
-        boardCheckStates.register(gameName) { addToken(playerName, position) }
+        boardCheckStates.tryRegister(gameName) { hasToken(playerName, position) }
     }
 
     override fun hasSpace(gameName: String, position: Position) = TicTacToeScriptGenerationCheck {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::boardHasSpace, gameName, position)
     }.asComposable {
-        boardCheckStates.register(gameName) { addSpace(position) }
+        boardCheckStates.tryRegister(gameName) { hasSpace(position) }
     }
 
     override fun hasState(gameName: String, moves: MoveMap) = TicTacToeScriptGenerationCheck {

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
@@ -55,7 +55,7 @@ class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
         fun hasSpace(position: Position) = at(position) { spaces.add(position) }
 
         private fun at(position: Position, fn: BoardCheckState.() -> Unit) = if (position in tokens || position in spaces) {
-            failure<BoardCheckState>(IllegalStateException("position $position is checked already"))
+            failure(IllegalStateException("position $position is checked already"))
         } else success(apply(fn))
     }
 }

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
@@ -51,7 +51,11 @@ class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
 
         private val isFullySpecified get() = tokens.size + spaces.size == Width * Height
 
-        fun addToken(player: String, position: Position) = apply { tokens[position] = player }
-        fun addSpace(position: Position) = apply { spaces.add(position) }
+        fun hasToken(player: String, position: Position) = at(position) { tokens[position] = player }
+        fun hasSpace(position: Position) = at(position) { spaces.add(position) }
+
+        private fun at(position: Position, fn: BoardCheckState.() -> Unit) = if (position in tokens || position in spaces) {
+            failure<BoardCheckState>(IllegalStateException("position $position is checked already"))
+        } else success(apply(fn))
     }
 }

--- a/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
+++ b/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
@@ -125,6 +125,39 @@ class TicTacToeScriptGeneratorTest {
         """.normalise())
     }
 
+    @Test
+    fun boardHasStateIsNotReconstructedIfDuplicateChecksAdded() {
+        val scenario = verifiableScenario {
+            given {
+                thereIsANewGame(gameA)
+            }
+            whenever {
+                placeToken(gameA, X, 1 to 1)
+                placeToken(gameA, O, 3 to 1)
+                placeToken(gameA, X, 1 to 3)
+                placeToken(gameA, O, 1 to 2)
+                placeToken(gameA, X, 3 to 3)
+            }
+            then {
+                boardHasToken(gameA, X, 1 to 1)
+                boardHasToken(gameA, O, 1 to 2)
+                boardHasToken(gameA, X, 1 to 3)
+                boardHasSpace(gameA, 2 to 1)
+                boardHasSpace(gameA, 2 to 2)
+                boardHasSpace(gameA, 2 to 3)
+                boardHasToken(gameA, O, 3 to 1)
+                boardHasSpace(gameA, 3 to 2)
+                boardHasToken(gameA, X, 3 to 3)
+                boardHasToken(gameA, O, 1 to 1)  // oops!
+            }
+        }
+
+        val lines = TicTacToeScriptGenerator().generateScript(scenario).lines()
+        assertFalse { lines.any { "boardHasState" in it } }
+        expect(6) { lines.count { "boardHasToken" in it } }
+        expect(4) { lines.count { "boardHasSpace" in it } }
+    }
+
     private fun String.normalise(): String {
         val noNewlines = replace(Regex("[ \n]+"), " ")
         val noTripleQuoteSpace = noNewlines.replace(Regex(" *${triple} *"), triple)


### PR DESCRIPTION
This proposal changes `CheckComposerMap` and `CheckComposerWrapper` so that they natively handle the possibility of composable checks failing to register.  An example, as given in the TicTacToe adapter, is when a composable check pulls in an assertion that contradicts a previous registered check.

When composers in wrappers or maps fail, they are effectively locked into a failure state - further attempts to register checks with them will be ignored.  This means that composer logic doesn't have to worry about handling error handling at any point other than registration.

This should mostly be a backwards-compatible change: the fallible forms of `register` are called `tryRegister`.  The `inner` property on `CheckComposerWrapper` has gone away to become a nullable called `compose`, which is technically breaking.