### PR TITLE
Fix propagation bug on composer maps and wrappers

### DIFF
--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -48,7 +48,7 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
 class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E> {
 
     private var _inner = Result.success(initial)
-    val composer: S? = _inner.getOrNull()
+    val composer: S? get() = _inner.getOrNull()
 
     /**
      * Registers a check on the inner composer by applying an effect to it.

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
@@ -1,6 +1,5 @@
 package com.anaplan.engineering.azuki.script.generation
 
-import com.anaplan.engineering.azuki.core.system.Behavior
 import com.anaplan.engineering.azuki.core.system.unsupportedBehavior
 import kotlin.test.*
 
@@ -30,7 +29,7 @@ class CheckComposerTest {
     }
 
     @Test
-    fun mapRegisterRemovesFromMapOnFailure() {
+    fun mapTryRegisterRemovesFromMapOnFailure() {
         val map = CheckComposerMap(Example::new)
         map.register("a") { increment() }
         assertIs<Forwards>(map["a"])
@@ -54,9 +53,18 @@ class CheckComposerTest {
     }
 
     @Test
+    fun mapPropagatesComposerFailures() {
+        val map = CheckComposerMap(Example::new)
+        val composer = map.register("a") { increment() }
+        assertIs<Forwards>(map["a"])
+        map.tryRegister("a") { Result.failure(IllegalStateException("oops")) }
+        assertIs<IllegalStateException>( composer.compose(NoScriptGenerationEnvironment).exceptionOrNull(),
+            "should have changed the inner object")
+    }
+
+    @Test
     fun wrapperRegisterReusesSameComposer() {
-        val original = Example.new("a")
-        val wrapper = CheckComposerWrapper(original)
+        val wrapper = CheckComposerWrapper(Example.new("a"))
         expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
         wrapper.register { increment() }
         wrapper.register { increment() }
@@ -67,9 +75,26 @@ class CheckComposerTest {
     }
 
     @Test
+    fun wrapperRegisterUpdatesComposerOnObjectChange() {
+        val wrapper = CheckComposerWrapper(Example.new("a"))
+        wrapper.register { increment() }
+        assertIs<Forwards>(wrapper.composer)
+        wrapper.register { reverse() }
+        assertIs<Backwards>(wrapper.composer)
+    }
+
+    @Test
+    fun wrapperTryRegisterNullifiesOnFailure() {
+        val wrapper = CheckComposerWrapper(Example.new("a"))
+        wrapper.register { increment() }
+        assertIs<Forwards>(wrapper.composer)
+        wrapper.tryRegister { Result.failure(IllegalStateException("oops")) }
+        assertNull(wrapper.composer, "a should now appear to have been removed")
+    }
+
+    @Test
     fun wrapperPropagatesComposerObjectChanges() {
-        val original = Example.new("a")
-        val wrapper = CheckComposerWrapper(original)
+        val wrapper = CheckComposerWrapper(Example.new("a"))
         expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
         wrapper.register { reverse() }
         expect("backwards(0)", "should have changed the inner object") { wrapper.toScript() }
@@ -77,8 +102,7 @@ class CheckComposerTest {
 
     @Test
     fun wrapperPropagatesComposerFailures() {
-        val original = Example.new("a")
-        val wrapper = CheckComposerWrapper(original)
+        val wrapper = CheckComposerWrapper(Example.new("a"))
         expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
         wrapper.tryRegister { Result.failure(IllegalStateException("oops")) }
         assertIs<IllegalStateException>(wrapper.compose(NoScriptGenerationEnvironment).exceptionOrNull(),


### PR DESCRIPTION
The last PR I put up accidentally introduced a bug whereby the inner composer of a `CheckComposerWrapper` was expressed as a field, not a property.  This meant that it would always evaluate to the initial composer, and not correctly track changes to the object.

The tests caught this issue but a) in the wrong place (it's a bug in the wrapper, but the tests surfaced it only in the map) and b) I neglected to run them properly.  As such, I've added some more tests, and actually run them this time.