### PR TITLE
Update jackson dependency

### DIFF
--- a/azuki-core/build.gradle
+++ b/azuki-core/build.gradle
@@ -5,10 +5,10 @@ plugins {
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-test-junit'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.jackson.module
     implementation 'org.semver4j:semver4j:5.2.2'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation libs.slf4j.api
 
     runtimeOnly 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
     implementation 'org.jetbrains.kotlin:kotlin-scripting-common'

--- a/azuki-core/build.gradle
+++ b/azuki-core/build.gradle
@@ -4,16 +4,16 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+    implementation libs.kotlin.test
     implementation libs.kotlinx.coroutines.core
     implementation libs.jackson.module
-    implementation 'org.semver4j:semver4j:5.2.2'
+    implementation libs.semver4j
     implementation libs.slf4j.api
 
-    runtimeOnly 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
-    implementation 'org.jetbrains.kotlin:kotlin-scripting-common'
-    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm'
-    implementation 'org.jetbrains.kotlin:kotlin-scripting-jvm-host'
+    runtimeOnly libs.kotlin.compiler.embeddable
+    implementation libs.kotlin.scripting.common
+    implementation libs.kotlin.scripting.jvm
+    implementation libs.kotlin.scripting.jvm.host
 }
 
 publishing {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/system/EacMetadata.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/system/EacMetadata.kt
@@ -4,6 +4,8 @@ package com.anaplan.engineering.azuki.core.system
 import com.anaplan.engineering.azuki.core.JvmSystemProperties.eacMetadataDirPropertyName
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.io.File
 
 typealias FunctionalElement = Int
@@ -27,7 +29,7 @@ data class EacMetadata(
     val scenarioName = "${functionalElement}-${behavior}-${methodName}"
 }
 
-internal val objectMapper = ObjectMapper().registerModule(KotlinModule())
+internal val objectMapper = jacksonObjectMapper()
 
 object EacMetadataRecorder {
 

--- a/azuki-listeners/build.gradle
+++ b/azuki-listeners/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':azuki-core')
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
+    implementation libs.jackson.module
 }
 
 publishing {

--- a/azuki-listeners/src/main/kotlin/com/anaplan/engineering/azuki/listeners/JsonResultRecorder.kt
+++ b/azuki-listeners/src/main/kotlin/com/anaplan/engineering/azuki/listeners/JsonResultRecorder.kt
@@ -4,6 +4,8 @@ import com.anaplan.engineering.azuki.core.runner.AzukiRunListener
 import com.anaplan.engineering.azuki.core.runner.ScenarioResult
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import java.io.File
 import java.util.concurrent.LinkedBlockingQueue
 
@@ -27,7 +29,7 @@ class JsonResultRecorder : AzukiRunListener {
         results.add(scenarioResult)
     }
 
-    private val objectMapper by lazy { ObjectMapper().registerModule(KotlinModule()) }
+    private val objectMapper by lazy { jacksonObjectMapper() }
 
     override fun suiteComplete(suiteName: String) {
         val suiteResults = mutableListOf<ScenarioResult>().apply {

--- a/azuki-result-reporter/build.gradle
+++ b/azuki-result-reporter/build.gradle
@@ -8,8 +8,8 @@ plugins {
 dependencies {
     implementation gradleApi()
     implementation project(':azuki-core')
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
-    implementation 'org.jetbrains.kotlinx:kotlinx-html-jvm:0.12.0'
+    implementation libs.jackson.module
+    implementation libs.kotlinx.html
 }
 
 gradlePlugin {

--- a/azuki-result-reporter/src/main/kotlin/com/anaplan/engineering/azuki/resultreporter/ScenarioReportGenerator.kt
+++ b/azuki-result-reporter/src/main/kotlin/com/anaplan/engineering/azuki/resultreporter/ScenarioReportGenerator.kt
@@ -5,7 +5,9 @@ import com.anaplan.engineering.azuki.core.runner.JUnitScenarioType
 import com.anaplan.engineering.azuki.core.runner.ScenarioResult
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import java.io.File
@@ -15,7 +17,7 @@ class ScenarioReportGenerator(
     val reportDir: File
 ) {
 
-    private val objectMapper by lazy { ObjectMapper().registerModule(KotlinModule()) }
+    private val objectMapper by lazy { jacksonObjectMapper() }
 
     fun generate() {
         val results = sourceFiles.flatMap {

--- a/azuki-runner/build.gradle
+++ b/azuki-runner/build.gradle
@@ -5,9 +5,9 @@ plugins {
 
 dependencies {
     api project(":azuki-core")
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation libs.slf4j.api
     runtimeOnly 'net.java.dev.jna:jna:5.8.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    runtimeOnly libs.slf4j.impl
 }
 
 publishing {

--- a/azuki-runner/build.gradle
+++ b/azuki-runner/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     api project(":azuki-core")
     implementation libs.slf4j.api
-    runtimeOnly 'net.java.dev.jna:jna:5.8.0'
+    runtimeOnly libs.jna
     runtimeOnly libs.slf4j.impl
 }
 

--- a/azuki-script-formatter/build.gradle
+++ b/azuki-script-formatter/build.gradle
@@ -4,9 +4,8 @@ plugins {
 }
 
 dependencies {
-    // 1.5.0+ are based on Kotlin 2.1, and would require the script parser to be pinned to the 2.1 version
-    implementation 'com.pinterest.ktlint:ktlint-rule-engine:1.4.1'
-    implementation 'com.pinterest.ktlint:ktlint-ruleset-standard:1.4.1'
+    implementation libs.ktlint.ruleEngine
+    implementation libs.ktlint.rulesetStandard
 }
 
 publishing {

--- a/azuki-script-generation/build.gradle
+++ b/azuki-script-generation/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(":azuki-script-formatter")
     api project(":azuki-core")
     api project(":azuki-declaration")
-    implementation 'org.jetbrains.kotlin:kotlin-test-junit'
+    implementation libs.kotlin.test
     implementation libs.slf4j.api
 
 }

--- a/azuki-script-generation/build.gradle
+++ b/azuki-script-generation/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api project(":azuki-core")
     api project(":azuki-declaration")
     implementation 'org.jetbrains.kotlin:kotlin-test-junit'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation libs.slf4j.api
 
 }
 

--- a/azuki-vdm/build.gradle
+++ b/azuki-vdm/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     api project(":azuki-core")
     api "com.anaplan.engineering:vdm-animation-api:$version"
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
+    implementation libs.jackson.module
     runtimeOnly "com.anaplan.engineering:vdm-animation-overture:$version"
 }
 

--- a/azuki-vdm/src/main/kotlin/com/anaplan/engineering/azuki/vdm/coverage/CoverageAggregator.kt
+++ b/azuki-vdm/src/main/kotlin/com/anaplan/engineering/azuki/vdm/coverage/CoverageAggregator.kt
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.databind.KeyDeserializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.File
 import java.nio.file.FileVisitResult
@@ -17,9 +20,10 @@ import java.nio.file.attribute.BasicFileAttributes
 
 class CoverageAggregator {
 
-    private val objectMapper = ObjectMapper()
-            .registerModule(KotlinModule())
-            .registerModule(LocationKeyDeserializerModule())
+    private val objectMapper = jsonMapper {
+        addModule(kotlinModule())
+        addModule(LocationKeyDeserializerModule())
+    }
 
     fun aggregate(coverageDirectory: File) =
             aggregate(locateFilesWithExtension(coverageDirectory, "cov")

--- a/azuki-vdm/src/main/kotlin/com/anaplan/engineering/azuki/vdm/coverage/CoverageRecorder.kt
+++ b/azuki-vdm/src/main/kotlin/com/anaplan/engineering/azuki/vdm/coverage/CoverageRecorder.kt
@@ -5,11 +5,12 @@ import com.anaplan.engineering.vdmanimation.api.FileCoverage
 import com.anaplan.engineering.vdmanimation.api.Location
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.io.File
 
 object CoverageRecorder {
 
-    private val objectMapper = ObjectMapper().registerModule(KotlinModule())
+    private val objectMapper = jacksonObjectMapper()
 
     fun recordJson(coverage: AnimationCoverage, coverageLocation: String? = System.getProperty("coverage.location")) {
         if (coverageLocation == null) return

--- a/azuki-verify/azuki-batch-api/build.gradle
+++ b/azuki-verify/azuki-batch-api/build.gradle
@@ -6,8 +6,7 @@ plugins {
 dependencies {
     api project(":azuki-runner")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation "org.jetbrains.kotlin:kotlin-reflect"
+    implementation libs.kotlin.reflect
 }
 
 publishing {

--- a/azuki-verify/azuki-batch-guided/build.gradle
+++ b/azuki-verify/azuki-batch-guided/build.gradle
@@ -6,19 +6,18 @@ plugins {
 dependencies {
     implementation project(":azuki-verify:azuki-batch-api")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation "org.jetbrains.kotlin:kotlin-reflect"
+    implementation libs.kotlin.reflect
 
     implementation libs.slf4j.api
-    implementation group: 'com.google.guava', name: 'guava', version: '28.2-jre'
+    implementation libs.guava
     implementation libs.jackson.module
     implementation libs.kotlinx.html
 
 
-    implementation group: 'net.java.dev.jna', name: 'jna', version: '5.8.0'
+    implementation libs.jna
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
-    testImplementation "io.mockk:mockk:1.10.2"
+    testImplementation libs.kotlin.test
+    testImplementation libs.mockk
     testRuntimeOnly libs.slf4j.impl
 
 }

--- a/azuki-verify/azuki-batch-guided/build.gradle
+++ b/azuki-verify/azuki-batch-guided/build.gradle
@@ -9,17 +9,17 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "org.jetbrains.kotlin:kotlin-reflect"
 
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
+    implementation libs.slf4j.api
     implementation group: 'com.google.guava', name: 'guava', version: '28.2-jre'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.12.3'
-    implementation 'org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.1'
+    implementation libs.jackson.module
+    implementation libs.kotlinx.html
 
 
     implementation group: 'net.java.dev.jna', name: 'jna', version: '5.8.0'
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
     testImplementation "io.mockk:mockk:1.10.2"
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    testRuntimeOnly libs.slf4j.impl
 
 }
 

--- a/azuki-verify/azuki-batch-guided/src/main/kotlin/com/anaplan/engineering/azuki/verify/batch/guided/GuidedScenarioBatch.kt
+++ b/azuki-verify/azuki-batch-guided/src/main/kotlin/com/anaplan/engineering/azuki/verify/batch/guided/GuidedScenarioBatch.kt
@@ -6,6 +6,7 @@ import com.anaplan.engineering.azuki.verify.batch.api.*
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.File
 import java.util.*
@@ -21,7 +22,7 @@ class GuidedScenarioBatch<S : BuildableScenario<*>, RC : ScenarioResultContext>:
         parsers.first() as ScenarioParser<S>
     }
 
-    private val objectMapper = ObjectMapper().registerModule(KotlinModule())
+    private val objectMapper = jacksonObjectMapper()
         // ignore orchestration properties
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 

--- a/azuki-verify/azuki-orchestrator/build.gradle
+++ b/azuki-verify/azuki-orchestrator/build.gradle
@@ -7,15 +7,15 @@ dependencies {
     implementation project(":azuki-runner")
     implementation project(":azuki-verify:azuki-batch-api")
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
+    implementation libs.kotlinx.serialization.json
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "org.jetbrains.kotlin:kotlin-reflect"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
-    implementation 'org.jetbrains.kotlinx:kotlinx-html-jvm:0.8.1'
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.jackson.module
+    implementation libs.kotlinx.html
 
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
+    implementation libs.slf4j.api
     implementation group: 'com.google.guava', name: 'guava', version: '28.2-jre'
 
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit"

--- a/azuki-verify/azuki-orchestrator/build.gradle
+++ b/azuki-verify/azuki-orchestrator/build.gradle
@@ -9,16 +9,15 @@ dependencies {
 
     implementation libs.kotlinx.serialization.json
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib"
-    implementation "org.jetbrains.kotlin:kotlin-reflect"
+    implementation libs.kotlin.reflect
     implementation libs.kotlinx.coroutines.core
     implementation libs.jackson.module
     implementation libs.kotlinx.html
 
     implementation libs.slf4j.api
-    implementation group: 'com.google.guava', name: 'guava', version: '28.2-jre'
+    implementation libs.guava
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit"
+    testImplementation libs.kotlin.test
 }
 
 publishing {

--- a/azuki-verify/azuki-orchestrator/src/main/kotlin/com/anaplan/engineering/azuki/verify/orchestrator/ScenarioOrchestrator.kt
+++ b/azuki-verify/azuki-orchestrator/src/main/kotlin/com/anaplan/engineering/azuki/verify/orchestrator/ScenarioOrchestrator.kt
@@ -6,6 +6,7 @@ import com.anaplan.engineering.azuki.verify.orchestrator.configuration.RunConfig
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -183,7 +184,7 @@ class ScenarioOrchestrator<OS : OrchestratableScenario, RC : ScenarioResultConte
     }
 }
 
-internal val objectMapper = ObjectMapper().registerModule(KotlinModule())
+internal val objectMapper = jacksonObjectMapper()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
 @ExperimentalCoroutinesApi

--- a/build-conventions/build.gradle
+++ b/build-conventions/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21'
+    implementation libs.kotlin.gradlePlugin
 }

--- a/build-conventions/settings.gradle
+++ b/build-conventions/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-conventions/src/main/groovy/azuki.kotlin-conventions.gradle
+++ b/build-conventions/src/main/groovy/azuki.kotlin-conventions.gradle
@@ -4,10 +4,8 @@ plugins {
 }
 
 dependencies {
-    implementation platform('org.jetbrains.kotlin:kotlin-bom:2.0.21')
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    implementation "org.jetbrains.kotlin:kotlin-reflect"
+    implementation platform(libs.kotlin.bom)
+    implementation libs.kotlin.reflect
 
-    testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit'
+    testImplementation libs.kotlin.test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,10 @@ task publishAllToMavenLocal {
     dependsOn gradle.includedBuild('azuki-platform').task(':publishToMavenLocal')
     dependsOn ':azuki-core:publishToMavenLocal'
     dependsOn ':azuki-declaration:publishToMavenLocal'
+    dependsOn ':azuki-listeners::publishToMavenLocal'
+    dependsOn ':azuki-runner:publishToMavenLocal'
     dependsOn ':azuki-script-formatter:publishToMavenLocal'
     dependsOn ':azuki-script-generation:publishToMavenLocal'
-    dependsOn ':azuki-runner:publishToMavenLocal'
     dependsOn ':azuki-vdm:publishToMavenLocal'
     dependsOn ':azuki-verify:azuki-batch-api:publishToMavenLocal'
     dependsOn ':azuki-verify:azuki-batch-guided:publishToMavenLocal'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,41 @@
 [versions]
-jackson = "2.17.1"
+kotlin = "2.0.21"
+kazuki = "0.3.0-alpha.1"
+# 1.5.0+ are based on Kotlin 2.1, and would require the script parser to be pinned to the 2.1 version
+ktlint = "1.4.1"
 
 [libraries]
-jackson-module = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
-
-slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "1.7.36" }
-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version = "2.17.0" }
+kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit" }
+kotlin-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable" }
+kotlin-scripting-common = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-common" }
+kotlin-scripting-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-jvm" }
+kotlin-scripting-jvm-host = { group = "org.jetbrains.kotlin", name = "kotlin-scripting-jvm-host" }
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version = "1.5.2"}
 kotlinx-html = { group = "org.jetbrains.kotlinx", name = "kotlinx-html-jvm", version = "0.12.0" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.2.2" }
+
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "1.7.36" }
+slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version = "2.17.0" }
+
+jackson-module = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.17.1" }
+
+guava = { group = "com.google.guava", name = "guava", version = "28.2-jre" }
+
+jna = { group = "net.java.dev.jna", name = "jna", version = "5.8.0" }
+
+mockk = { group = "io.mockk", name = "mockk", version = "1.10.2" }
+
+semver4j = { group = "org.semver4j", name = "semver4j", version = "5.2.2" }
+
+ktlint-ruleEngine = { group = "com.pinterest.ktlint", name = "ktlint-rule-engine", version.ref = "ktlint" }
+ktlint-rulesetStandard = { group = "com.pinterest.ktlint", name = "ktlint-ruleset-standard", version.ref = "ktlint" }
+
+kazuki-toolkit = { group = "com.anaplan.engineering", name = "kazuki-toolkit", version.ref = "kazuki"}
+kazuki-ksp = { group = "com.anaplan.engineering", name = "kazuki-ksp", version.ref = "kazuki"}
+
+[plugins]
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,12 @@
+[versions]
+jackson = "2.17.1"
+
+[libraries]
+jackson-module = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
+
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "1.7.36" }
+slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version = "2.17.0" }
+
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version = "1.5.2"}
+kotlinx-html = { group = "org.jetbrains.kotlinx", name = "kotlinx-html-jvm", version = "0.12.0" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.2.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "1.7.36" }
 slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version = "2.17.0" }
 
-jackson-module = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.17.1" }
+jackson-module = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "2.20.1" }
 
 guava = { group = "com.google.guava", name = "guava", version = "28.2-jre" }
 

--- a/graphs/adapter-jgrapht/build.gradle
+++ b/graphs/adapter-jgrapht/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     implementation project(":graphs:adapter-declaration")
     implementation "org.jgrapht:jgrapht-core:1.5.2"
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+    implementation libs.slf4j.api
 }

--- a/graphs/adapter-script-generation/build.gradle
+++ b/graphs/adapter-script-generation/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":graphs:dsl")
     api project(":graphs:adapter-declaration")
     implementation project(":azuki-script-generation")
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+    implementation libs.slf4j.api
 }

--- a/graphs/dsl/build.gradle
+++ b/graphs/dsl/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":azuki-core")
     api project(":graphs:adapter-api")
 
-    implementation "org.jetbrains.kotlin:kotlin-test-junit"
+    implementation libs.kotlin.test
 }

--- a/graphs/eacs/build.gradle
+++ b/graphs/eacs/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     api project(":graphs:dsl")
     jgrapht project(":graphs:adapter-jgrapht")
     jung project(":graphs:adapter-jung")
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    testRuntimeOnly libs.slf4j.impl
 }
 
 task jgraphtClasspathJar(type: Jar) {

--- a/graphs/script-runner/build.gradle
+++ b/graphs/script-runner/build.gradle
@@ -16,7 +16,7 @@ configurations {
 dependencies {
     runner project(":graphs:dsl")
     runner project(":azuki-runner")
-    runner 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    runner libs.slf4j.impl
 
     jgrapht project(":graphs:adapter-jgrapht")
     jung project(":graphs:adapter-jung")

--- a/graphs/tests/build.gradle
+++ b/graphs/tests/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     api project(":graphs:dsl")
     jgrapht project(":graphs:adapter-jgrapht")
     jung project(":graphs:adapter-jung")
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    testRuntimeOnly libs.slf4j.impl
 }
 
 task jgraphtClasspathJar(type: Jar) {

--- a/tictactoe/adapter-implementation/build.gradle
+++ b/tictactoe/adapter-implementation/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api project(":tictactoe:adapter-declaration")
     compileOnly project(":tictactoe:implementation")
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
+    implementation libs.slf4j.api
+    implementation libs.kotlinx.serialization.json
+    implementation libs.jackson.module
 }

--- a/tictactoe/adapter-implementation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/implementation/SampleSystemFactory.kt
+++ b/tictactoe/adapter-implementation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/implementation/SampleSystemFactory.kt
@@ -14,10 +14,12 @@ import com.anaplan.engineering.azuki.tictactoe.adapter.implementation.declaratio
 import com.anaplan.engineering.azuki.tictactoe.implementation.GameManager
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Files
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 class SampleSystemFactory :
     PersistableSystemFactory<TicTacToeActionFactory, TicTacToeCheckFactory, NoQueryFactory, NoActionGeneratorFactory, NoSystemDefaults, SampleSystem> {
@@ -102,8 +104,7 @@ class SampleSystem(
         private val declarationStateBuilder = DeclarationStateBuilder(::TicTacToeDeclarationState)
     }
 
-    private val objectMapper = ObjectMapper()
-        .registerModule(KotlinModule())
+    private val objectMapper = jacksonObjectMapper()
 
     data class PersistableSystemState(
         val activeGames: List<String>,

--- a/tictactoe/adapter-kazuki/build.gradle
+++ b/tictactoe/adapter-kazuki/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     api project(":tictactoe:adapter-declaration")
     compileOnly project(":tictactoe:kazuki")
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+    implementation libs.slf4j.api
 }

--- a/tictactoe/adapter-script-generation/build.gradle
+++ b/tictactoe/adapter-script-generation/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":tictactoe:dsl")
     api project(":tictactoe:adapter-declaration")
     implementation project(":azuki-script-generation")
-    implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
+    implementation libs.slf4j.api
 }

--- a/tictactoe/dsl/build.gradle
+++ b/tictactoe/dsl/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     api project(":azuki-core")
     api project(":tictactoe:adapter-api")
 
-    implementation "org.jetbrains.kotlin:kotlin-test-junit"
+    implementation libs.kotlin.test
 }

--- a/tictactoe/eacs/build.gradle
+++ b/tictactoe/eacs/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     sampleImplementationV1 project(":tictactoe:implementation-v1")
     sampleImplementationV2 project(":tictactoe:adapter-implementation")
     sampleImplementationV2 project(":tictactoe:implementation-v2")
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    testRuntimeOnly libs.slf4j.impl
 }
 
 task vdmClasspathJar(type: Jar) {

--- a/tictactoe/implementation-v1/build.gradle
+++ b/tictactoe/implementation-v1/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(":tictactoe:implementation")
-    implementation "org.jetbrains.kotlin:kotlin-test-junit"
+    implementation libs.kotlin.test
     implementation libs.kotlinx.serialization.json
     implementation libs.jackson.module
     implementation libs.slf4j.api

--- a/tictactoe/implementation-v1/build.gradle
+++ b/tictactoe/implementation-v1/build.gradle
@@ -5,9 +5,9 @@ plugins {
 dependencies {
     implementation project(":tictactoe:implementation")
     implementation "org.jetbrains.kotlin:kotlin-test-junit"
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    implementation libs.kotlinx.serialization.json
+    implementation libs.jackson.module
+    implementation libs.slf4j.api
+    testRuntimeOnly libs.slf4j.impl
 
 }

--- a/tictactoe/implementation-v2/build.gradle
+++ b/tictactoe/implementation-v2/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(":tictactoe:implementation")
-    implementation "org.jetbrains.kotlin:kotlin-test-junit"
+    implementation libs.kotlin.test
     implementation libs.kotlinx.serialization.json
     implementation libs.jackson.module
     implementation libs.slf4j.api

--- a/tictactoe/implementation-v2/build.gradle
+++ b/tictactoe/implementation-v2/build.gradle
@@ -5,9 +5,9 @@ plugins {
 dependencies {
     implementation project(":tictactoe:implementation")
     implementation "org.jetbrains.kotlin:kotlin-test-junit"
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    implementation libs.kotlinx.serialization.json
+    implementation libs.jackson.module
+    implementation libs.slf4j.api
+    testRuntimeOnly libs.slf4j.impl
 
 }

--- a/tictactoe/implementation/build.gradle
+++ b/tictactoe/implementation/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-test-junit"
+    implementation libs.kotlin.test
     implementation libs.kotlinx.serialization.json
     implementation libs.jackson.module
     implementation libs.slf4j.api

--- a/tictactoe/implementation/build.gradle
+++ b/tictactoe/implementation/build.gradle
@@ -4,9 +4,9 @@ plugins {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-test-junit"
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    implementation libs.kotlinx.serialization.json
+    implementation libs.jackson.module
+    implementation libs.slf4j.api
+    testRuntimeOnly libs.slf4j.impl
 
 }

--- a/tictactoe/implementation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/implementation/GameManager.kt
+++ b/tictactoe/implementation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/implementation/GameManager.kt
@@ -2,7 +2,9 @@ package com.anaplan.engineering.azuki.tictactoe.implementation
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.util.*
@@ -44,8 +46,7 @@ class GameManager(private val store: File) {
         return game
     }
 
-    private val objectMapper = ObjectMapper()
-        .registerModule(KotlinModule())
+    private val objectMapper = jacksonObjectMapper()
 
     val gameCreator: GameCreator by lazy {
         val loader = ServiceLoader.load(GameCreator::class.java)

--- a/tictactoe/kazuki/build.gradle
+++ b/tictactoe/kazuki/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     api "com.anaplan.engineering:kazuki-toolkit:0.3.0-alpha.1"
     ksp "com.anaplan.engineering:kazuki-ksp:0.3.0-alpha.1"
     implementation "org.jetbrains.kotlin:kotlin-test-junit"
-    implementation 'org.slf4j:slf4j-api:1.7.36'
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    implementation libs.slf4j.api
+    testRuntimeOnly libs.slf4j.impl
 }
 
 ksp {

--- a/tictactoe/kazuki/build.gradle
+++ b/tictactoe/kazuki/build.gradle
@@ -1,16 +1,15 @@
 plugins {
     id 'azuki.common-conventions'
-    id 'org.jetbrains.kotlin.jvm' version("2.0.21")
+    alias(libs.plugins.kotlin)
     id 'com.google.devtools.ksp' version("2.0.21-1.0.25")
 }
 
 dependencies {
-    implementation platform('org.jetbrains.kotlin:kotlin-bom:1.9.10')
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    implementation "org.jetbrains.kotlin:kotlin-reflect"
-    api "com.anaplan.engineering:kazuki-toolkit:0.3.0-alpha.1"
-    ksp "com.anaplan.engineering:kazuki-ksp:0.3.0-alpha.1"
-    implementation "org.jetbrains.kotlin:kotlin-test-junit"
+    implementation platform(libs.kotlin.bom)
+    implementation libs.kotlin.reflect
+    api libs.kazuki.toolkit
+    ksp libs.kazuki.ksp
+    implementation libs.kotlin.test
     implementation libs.slf4j.api
     testRuntimeOnly libs.slf4j.impl
 }

--- a/vdm-animation/settings.gradle
+++ b/vdm-animation/settings.gradle
@@ -3,3 +3,11 @@ include(
     "vdm-animation-overture",
 )
 includeBuild("../build-conventions")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/vdm-animation/vdm-animation-overture/build.gradle
+++ b/vdm-animation/vdm-animation-overture/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(":vdm-animation-api")
     implementation group: 'org.overturetool.core', name: 'interpreter', version: '3.0.2'
     implementation group: 'org.overturetool.core.annotations', name: 'provided', version: '3.0.2'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation libs.slf4j.api
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.mockito.kotlin', name: 'mockito-kotlin', version: '3.2.0'
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-reflect'


### PR DESCRIPTION
Besides making dependency versions consistent across the repository (e.g. we were using two different versions of slf4j), the only version that is being changed here is the upgrade of `jackson-module-kotlin` from 2.12.5 to 2.20.1.