### PR TITLE
Rollup of fixups to script builder pattern

### DIFF
--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/RunnableScenarioClassGenerator.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/RunnableScenarioClassGenerator.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
 /**
  * Generates full Kotlin JUnit runnable scenario classes given a scenario script.
  */
-abstract class RunnableScenarioClassGenerator<S : RunnableScenario<*, *, *, *, *, *, *, *, *, *, *, *>>(
+open class RunnableScenarioClassGenerator<S : RunnableScenario<*, *, *, *, *, *, *, *, *, *, *, *>>(
     val adapterSpecificImports: List<String>,
     val scenarioClass: KClass<S>,
 ) {

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/RunnableScenarioClassGenerator.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/RunnableScenarioClassGenerator.kt
@@ -41,7 +41,7 @@ open class RunnableScenarioClassGenerator<S : RunnableScenario<*, *, *, *, *, *,
         appendLine("    fun test() {")
         appendLine(scenarioScript.render {
             indentLevel = 2
-            scriptType = ScriptType.Standalone
+            scriptType = ScriptType.Inline
             // We're going to format the whole test-case anyway, so formatting twice is pointless
             formatter = Formatter.None
         })

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
@@ -163,7 +163,7 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     val elements get() = if (inner is ScriptElementList<*>) inner.elements else listOf(inner)
 
     override fun render(ctx: RenderContext) = with(ctx) {
-        listOf("$indent$header", inner.render(nextIndentLevel), indent).joinToString("\n")
+        listOf("$indent$header {", inner.render(nextIndentLevel), "$indent}").joinToString("\n")
     }
 
     /**

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
@@ -163,11 +163,7 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     val elements get() = if (inner is ScriptElementList<*>) inner.elements else listOf(inner)
 
     override fun render(ctx: RenderContext) = with(ctx) {
-        """
-        $indent$header {
-        ${inner.render(nextIndentLevel)}
-        $indent}
-        """.trimIndent()
+        listOf("$indent$header", inner.render(nextIndentLevel), indent).joinToString("\n")
     }
 
     /**

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
@@ -38,11 +38,13 @@ abstract class BasicScriptBlockBuilder() {
 
     /**
      * Supplies a script fragment to this builder directly.
+     * Note that all directly-supplied fragments and elements appear _before_ those specified by other means.
      */
     operator fun String.unaryPlus() = +ScriptStringFragment(this)
 
     /**
      * Supplies a script element to this builder directly.
+     * Note that all directly-supplied fragments and elements appear _before_ those specified by other means.
      */
     operator fun ScriptElement.unaryPlus() {
         explicitScriptElements += this

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
@@ -72,6 +72,7 @@ abstract class BasicStageBuilder<in S : BuildableScenario<*>, E : ScriptGenerati
     }
 }
 
+@ScriptGenerationDsl
 class GivenBuilder<out AF : ActionFactory, DS : DeclarationState, E : ScriptGenerationEnvironment>(
     private val actionFactory: AF, private val declarationStateFactory: DeclarationStateFactory<DS>, environment: E
 ) : BasicStageBuilder<BuildableScenario<in AF>, E>(environment) {
@@ -101,6 +102,7 @@ class GivenBuilder<out AF : ActionFactory, DS : DeclarationState, E : ScriptGene
     }
 }
 
+@ScriptGenerationDsl
 class WheneverBuilder<out AF : ActionFactory, E : ScriptGenerationEnvironment>(val actionFactory: AF, environment: E) :
     BasicStageBuilder<BuildableScenario<in AF>, E>(environment) {
 
@@ -124,6 +126,7 @@ class WheneverBuilder<out AF : ActionFactory, E : ScriptGenerationEnvironment>(v
     private val commands = mutableListOf<ScriptGenerationAction<E>>()
 }
 
+@ScriptGenerationDsl
 class ThenBuilder<out CF : CheckFactory, E : ScriptGenerationEnvironment>(
     private val checkFactory: CF, environment: E
 ) : BasicStageBuilder<VerifiableScenario<*, in CF>, E>(environment) {
@@ -171,6 +174,7 @@ class ThenBuilder<out CF : CheckFactory, E : ScriptGenerationEnvironment>(
     private val checks = mutableListOf<ScriptGenerationCheck<E>>()
 }
 
+@ScriptGenerationDsl
 class QueryBuilder<out QF : QueryFactory, E : ScriptGenerationEnvironment>(
     private val queryFactory: QF, environment: E
 ) : BasicStageBuilder<ScenarioWithQueries<*, in QF>, E>(environment) {
@@ -247,6 +251,7 @@ abstract class GenerateBlocksBuilder<out AF : ActionFactory, out QF : QueryFacto
 /**
  * Builds an individual block in a list of generate blocks.
  */
+@ScriptGenerationDsl
 class GenerateBlockBuilder() : BasicScriptBlockBuilder() {
 
     fun build(body: GenerateBlockBuilder.() -> Unit) = apply(body).scriptElements
@@ -263,6 +268,7 @@ class GenerateBlockBuilder() : BasicScriptBlockBuilder() {
     override val builtScriptElements get() = actionGenerators.map { ScriptStringFragment(it.getActionGeneratorScript()) }
 }
 
+@ScriptGenerationDsl
 class GivenGenerateBlocksBuilder<out AF : ActionFactory, out QF : QueryFactory, out AGF : ActionGeneratorFactory>(
     actionGeneratorFactory: AGF
 ) : GenerateBlocksBuilder<AF, QF, AGF>(actionGeneratorFactory) {
@@ -271,6 +277,7 @@ class GivenGenerateBlocksBuilder<out AF : ActionFactory, out QF : QueryFactory, 
         scenario.givenActionGenerations(actionGeneratorFactory)
 }
 
+@ScriptGenerationDsl
 class WheneverGenerateBlocksBuilder<out AF : ActionFactory, out QF : QueryFactory, out AGF : ActionGeneratorFactory>(
     actionGeneratorFactory: AGF
 ) : GenerateBlocksBuilder<AF, QF, AGF>(actionGeneratorFactory) {
@@ -299,3 +306,7 @@ private inline fun <reified U> logRefineFailure(failure: Any?) {
     val why = if (failure is U) "unsupported" else "wrong type"
     BasicStageBuilder.Log.error(" * {}: {}", why, failure)
 }
+
+@DslMarker
+@Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
+annotation class ScriptGenerationDsl

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
@@ -37,17 +37,15 @@ import kotlin.collections.plusAssign
 abstract class BasicScriptBlockBuilder() {
 
     /**
-     * Supplies script fragments to this builder directly.
+     * Supplies a script fragment to this builder directly.
      */
-    fun fromFragments(vararg fragments: String) {
-        fromElements(fragments.map(::ScriptStringFragment))
-    }
+    operator fun String.unaryPlus() = +ScriptStringFragment(this)
 
     /**
-     * Supplies script elements to this builder directly.
+     * Supplies a script element to this builder directly.
      */
-    fun fromElements(elements: List<ScriptElement>) {
-        explicitScriptElements += elements
+    operator fun ScriptElement.unaryPlus() {
+        explicitScriptElements += this
     }
 
     private val explicitScriptElements = mutableListOf<ScriptElement>()
@@ -148,7 +146,7 @@ class ThenBuilder<out CF : CheckFactory, E : ScriptGenerationEnvironment>(
      * Populates the script with checks derived from these validatable answers.
      */
     fun fromValidatableAnswers(answers: Collection<ValidatableAnswer<*, in CF>>) =
-        fromChecks(answers.flatMap { it.createValidationChecks(checkFactory)})
+        fromChecks(answers.flatMap { it.createValidationChecks(checkFactory) })
 
     /**
      * Populates the script with these checks.
@@ -236,12 +234,11 @@ abstract class GenerateBlocksBuilder<out AF : ActionFactory, out QF : QueryFacto
     /**
      * Adds the generate blocks from this oracle scenario.
      */
-    fun fromScenario(scenario: OracleScenario<in AF, in QF, in AGF>) =
-        actionGeneratorsFromScenario(scenario).forEach {
-            block {
-                fromActionGenerators(it)
-            }
+    fun fromScenario(scenario: OracleScenario<in AF, in QF, in AGF>) = actionGeneratorsFromScenario(scenario).forEach {
+        block {
+            fromActionGenerators(it)
         }
+    }
 
     protected abstract fun actionGeneratorsFromScenario(scenario: OracleScenario<in AF, in QF, in AGF>): List<List<ActionGenerator>>
 

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationService.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationService.kt
@@ -14,7 +14,8 @@ import com.anaplan.engineering.azuki.declaration.*
 class ScriptGenerationService<
     out AF : ActionFactory,
     out CF : CheckFactory,
-    out QF : QueryFactory,
+    out QQF : QueryFactory,
+    out VQF : QueryFactory,
     out AGF : ActionGeneratorFactory,
     DS : DeclarationState,
     E : ScriptGenerationEnvironment,
@@ -25,8 +26,8 @@ class ScriptGenerationService<
     internal val declarationStateFactory: DeclarationStateFactory<DS>,
     // optional parameters
     internal val environmentFactory: ScriptGenerationEnvironmentFactory<E>,
-    internal val queryQueryFactory: QF,
-    internal val verifyQueryFactory: QF,
+    internal val queryQueryFactory: QQF,
+    internal val verifyQueryFactory: VQF,
     internal val actionGeneratorFactory: AGF,
 ) {
 
@@ -38,7 +39,8 @@ class ScriptGenerationService<
         out AF : ActionFactory,
         out CF : CheckFactory,
         // optional factories (these require calling 'withXYZFactory')
-        out QF : QueryFactory,
+        out QQF : QueryFactory,
+        out VQF : QueryFactory,
         out AGF : ActionGeneratorFactory,
         // mandatory non-factory parameters
         DS : DeclarationState,
@@ -51,8 +53,8 @@ class ScriptGenerationService<
         internal val declarationStateFactory: DeclarationStateFactory<DS>,
         // optional parameters
         internal val environmentFactory: ScriptGenerationEnvironmentFactory<E>,
-        internal val queryQueryFactory: QF,
-        internal val verifyQueryFactory: QF,
+        internal val queryQueryFactory: QQF,
+        internal val verifyQueryFactory: VQF,
         internal val actionGeneratorFactory: AGF,
     ) {
 
@@ -81,14 +83,27 @@ class ScriptGenerationService<
             )
 
         /**
-         * Adds query factories to this service, changing the type of accepted scenarios accordingly.
+         * Adds a `query`-query factory to this service, changing the type of accepted scenarios accordingly.
          */
-        fun <N : QueryFactory> withQueryFactories(query: N, verify: N) = Builder(
+        fun <N : QueryFactory> withQueryFactory(query: N) = Builder(
             actionFactory,
             checkFactory,
             declarationStateFactory,
             environmentFactory,
             queryQueryFactory = query,
+            verifyQueryFactory,
+            actionGeneratorFactory,
+        )
+
+        /**
+         * Adds a `verify`-query factory to this service, changing the type of accepted scenarios accordingly.
+         */
+        fun <N : QueryFactory> withVerifyFactory(verify: N) = Builder(
+            actionFactory,
+            checkFactory,
+            declarationStateFactory,
+            environmentFactory,
+            queryQueryFactory,
             verifyQueryFactory = verify,
             actionGeneratorFactory,
         )
@@ -138,7 +153,7 @@ class ScriptGenerationService<
     /**
      * Generates a script for a query scenario.
      */
-    fun generateQueryScenario(scenario: ScenarioWithQueries<in AF, in QF>) = given {
+    fun generateQueryScenario(scenario: ScenarioWithQueries<in AF, in QQF>) = given {
         fromScenario(scenario)
     }.whenever {
         fromScenario(scenario)
@@ -152,7 +167,7 @@ class ScriptGenerationService<
      * This allows the same builder to be used for the oracle scenario and for the verifiable scenario derived from its
      * answers.
      */
-    fun getOracleScenarioBuilder(scenario: OracleScenario<in AF, in QF, in AGF>) = given {
+    fun getOracleScenarioBuilder(scenario: OracleScenario<in AF, in VQF, in AGF>) = given {
         fromScenario(scenario)
     }.generateBlocks {
         fromScenario(scenario)
@@ -167,7 +182,7 @@ class ScriptGenerationService<
     /**
      * Generates a script for an oracle scenario.
      */
-    fun generateOracleScenario(scenario: OracleScenario<in AF, in QF, in AGF>) =
+    fun generateOracleScenario(scenario: OracleScenario<in AF, in VQF, in AGF>) =
         getOracleScenarioBuilder(scenario).oracleScenario
 
     /*
@@ -219,7 +234,7 @@ class ScriptGenerationService<
     /**
      * Builders that allow `.generate {}` (given, whenever, and the two types of generate block themselves).
      */
-    interface AllowsGenerate<out AF : ActionFactory, out QF : QueryFactory, out AGF : ActionGeneratorFactory, out N> {
+    interface AllowsGenerate<out AF : ActionFactory, out VQF : QueryFactory, out AGF : ActionGeneratorFactory, out N> {
         /**
          * Constructs a single generate block by mixing in generators from one or more sources.
          */
@@ -228,11 +243,11 @@ class ScriptGenerationService<
         /**
          * Constructs multiple generate blocks by mixing in generators from one or more sources.
          */
-        fun generateBlocks(body: GenerateBlocksBuilder<AF, QF, AGF>.() -> Unit): N
+        fun generateBlocks(body: GenerateBlocksBuilder<AF, VQF, AGF>.() -> Unit): N
     }
 
     inner class Given(internal val environment: E, contents: List<ScriptElement>) :
-        AllowsGenerate<AF, QF, AGF, GivenGenerate> {
+        AllowsGenerate<AF, VQF, AGF, GivenGenerate> {
 
         val block = ScriptBlock("given", contents)
 
@@ -245,8 +260,8 @@ class ScriptGenerationService<
         /**
          * Constructs multiple given-generate blocks by mixing in generators from one or more sources.
          */
-        override fun generateBlocks(body: GenerateBlocksBuilder<AF, QF, AGF>.() -> Unit) =
-            GivenGenerate(this, GivenGenerateBlocksBuilder<AF, QF, AGF>(actionGeneratorFactory).build(body))
+        override fun generateBlocks(body: GenerateBlocksBuilder<AF, VQF, AGF>.() -> Unit) =
+            GivenGenerate(this, GivenGenerateBlocksBuilder<AF, VQF, AGF>(actionGeneratorFactory).build(body))
     }
 
     abstract inner class Whenever(contents: List<ScriptElement>) {
@@ -270,7 +285,7 @@ class ScriptGenerationService<
         /**
          * Constructs a query block by mixing in queries from one or more sources.
          */
-        fun query(body: QueryBuilder<QF, E>.() -> Unit) =
+        fun query(body: QueryBuilder<QQF, E>.() -> Unit) =
             GivenWheneverQuery(this, QueryBuilder(queryQueryFactory, environment).build(body))
     }
 
@@ -300,7 +315,7 @@ class ScriptGenerationService<
      * A list of generate blocks in 'given' position.
      */
     inner class GivenGenerate(val given: Given, subBlocks: List<ScriptBlock>) :
-        AllowsGenerate<AF, QF, AGF, GivenGenerate> {
+        AllowsGenerate<AF, VQF, AGF, GivenGenerate> {
 
         var blockList = ScriptElementList<ScriptBlock>(subBlocks)
 
@@ -310,7 +325,7 @@ class ScriptGenerationService<
         fun whenever(body: WheneverBuilder<AF, E>.() -> Unit) =
             GivenGenerateWhenever(this, WheneverBuilder(actionFactory, environment).build(body))
 
-        override fun generateBlocks(body: GenerateBlocksBuilder<AF, QF, AGF>.() -> Unit) = apply {
+        override fun generateBlocks(body: GenerateBlocksBuilder<AF, VQF, AGF>.() -> Unit) = apply {
             blockList += given.generateBlocks(body).blockList
         }
 
@@ -321,23 +336,23 @@ class ScriptGenerationService<
      * A whenever block following a given-generate block.
      */
     inner class GivenGenerateWhenever(val givenGenerate: GivenGenerate, contents: List<ScriptElement>) :
-        Whenever(contents), AllowsGenerate<AF, QF, AGF, GivenGenerateWheneverGenerate> {
+        Whenever(contents), AllowsGenerate<AF, VQF, AGF, GivenGenerateWheneverGenerate> {
 
         override val given = givenGenerate.given
 
         /**
          * Constructs multiple whenever-generate blocks by mixing in generators from one or more sources.
          */
-        override fun generateBlocks(body: GenerateBlocksBuilder<AF, QF, AGF>.() -> Unit) =
+        override fun generateBlocks(body: GenerateBlocksBuilder<AF, VQF, AGF>.() -> Unit) =
             GivenGenerateWheneverGenerate(this,
-                WheneverGenerateBlocksBuilder<AF, QF, AGF>(actionGeneratorFactory).build(body))
+                WheneverGenerateBlocksBuilder<AF, VQF, AGF>(actionGeneratorFactory).build(body))
     }
 
     /**
      * A list of generate blocks in 'whenever' position.
      */
     inner class GivenGenerateWheneverGenerate(val whenever: GivenGenerateWhenever, subBlocks: List<ScriptBlock>) :
-        AllowsGenerate<AF, QF, AGF, GivenGenerateWheneverGenerate> {
+        AllowsGenerate<AF, VQF, AGF, GivenGenerateWheneverGenerate> {
 
         var blockList = ScriptElementList<ScriptBlock>(subBlocks)
         val givenGenerate = whenever.givenGenerate
@@ -346,10 +361,10 @@ class ScriptGenerationService<
         /**
          * Constructs a verify block by mixing in queries from one or more sources.
          */
-        fun verify(body: QueryBuilder<QF, E>.() -> Unit) =
+        fun verify(body: QueryBuilder<VQF, E>.() -> Unit) =
             GivenGenerateWheneverGenerateVerify(this, QueryBuilder(verifyQueryFactory, environment).build(body))
 
-        override fun generateBlocks(body: GenerateBlocksBuilder<AF, QF, AGF>.() -> Unit) = apply {
+        override fun generateBlocks(body: GenerateBlocksBuilder<AF, VQF, AGF>.() -> Unit) = apply {
             blockList += whenever.generateBlocks(body).blockList
         }
 

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationService.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationService.kt
@@ -169,26 +169,6 @@ class ScriptGenerationService<
     fun generateOracleScenario(scenario: OracleScenario<in AF, in QF, in AGF>) =
         getOracleScenarioBuilder(scenario).oracleScenario
 
-    /**
-     * Generates a script for a scenario whose type (verifiable, oracle, query) isn't known until run-time, by
-     * refining it into one of the types of scenario we can handle.
-     *
-     * For type safety, this wrapper takes projection methods to try map the base scenario type to all the specific
-     * scenario types the generator supports.  These should usually be implemented as `{ this as? NarrowScenarioType }`.
-     * If a projection method is not given, scenarios of that kind won't be handled and will result in an exception.
-     */
-    fun <S : BuildableScenario<in AF>> generateScenarioOfUnknownType(
-        scenario: S,
-        asVerifiable: S.() -> VerifiableScenario<in AF, in CF>? = { null },
-        asOracle: S.() -> OracleScenario<in AF, in QF, in AGF>? = { null },
-        asQuery: S.() -> ScenarioWithQueries<in AF, in QF>? = { null },
-    ) = listOf(
-        asVerifiable(scenario)?.let { generateVerifiableScenario(it) },
-        asOracle(scenario)?.let { generateOracleScenario(it) },
-        asQuery(scenario)?.let { generateQueryScenario(it) },
-    ).firstNotNullOfOrNull { it }
-        ?: throw IllegalArgumentException("unsupported scenario type: ${this::class.simpleName}")
-
     /*
      * Script builder API
      */

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationService.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationService.kt
@@ -10,6 +10,7 @@ import com.anaplan.engineering.azuki.declaration.*
 /**
  * The main endpoint for script generation tasks.
  */
+@ScriptGenerationDsl
 class ScriptGenerationService<
     out AF : ActionFactory,
     out CF : CheckFactory,

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationSystemWriter.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationSystemWriter.kt
@@ -16,7 +16,7 @@ import java.io.File
 abstract class ScriptGenerationSystemWriter<AF : ActionFactory, CF : CheckFactory, QF : QueryFactory, AGF : ActionGeneratorFactory> :
     SystemWriter<AF, CF, QF, AGF> {
 
-    protected abstract val scriptGeneration: ScriptGenerationService<AF, CF, QF, AGF, *, *>
+    protected abstract val scriptGeneration: ScriptGenerationService<AF, CF, QF, QF, AGF, *, *>
     protected abstract val classGeneration: RunnableScenarioClassGenerator<*>
     protected abstract val outputDir: File
 

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
@@ -107,20 +107,20 @@ class ScriptGenerationTesting<S : BuildableScenario<*>>(
 /**
  * Creates a test helper for verifiable scenarios, given a way to parse them.
  */
-fun <AF : ActionFactory, CF : CheckFactory> ScriptGenerationService<AF, CF, *, *, *, *>.createVerifiableTestHelper(
+fun <AF : ActionFactory, CF : CheckFactory> ScriptGenerationService<AF, CF, *, *, *, *, *>.createVerifiableTestHelper(
     parser: ScenarioParser<VerifiableScenario<AF, CF>>
 ) = ScriptGenerationTesting(::generateVerifiableScenario, parser)
 
 /**
  * Creates a test helper for oracle scenarios, given a way to parse them.
  */
-fun <AF : ActionFactory, QF : QueryFactory, AGF: ActionGeneratorFactory> ScriptGenerationService<AF, *, QF, AGF, *, *>.createOracleTestHelper(
-    parser: ScenarioParser<OracleScenario<AF, QF, AGF>>
+fun <AF : ActionFactory, VQF : QueryFactory, AGF: ActionGeneratorFactory> ScriptGenerationService<AF, *, *, VQF, AGF, *, *>.createOracleTestHelper(
+    parser: ScenarioParser<OracleScenario<AF, VQF, AGF>>
 ) = ScriptGenerationTesting(::generateOracleScenario, parser)
 
 /**
  * Creates a test helper for query scenarios, given a way to parse them.
  */
-fun <AF : ActionFactory, QF : QueryFactory> ScriptGenerationService<AF, *, QF, *, *, *>.createQueryTestHelper(
-    parser: ScenarioParser<ScenarioWithQueries<AF, QF>>
+fun <AF : ActionFactory, QQF : QueryFactory> ScriptGenerationService<AF, *, QQF, *, *, *, *>.createQueryTestHelper(
+    parser: ScenarioParser<ScenarioWithQueries<AF, QQF>>
 ) = ScriptGenerationTesting(::generateQueryScenario, parser)

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
@@ -4,7 +4,13 @@ import com.anaplan.engineering.azuki.core.parser.ScenarioParser
 import com.anaplan.engineering.azuki.core.parser.ScenarioParsingContext
 import com.anaplan.engineering.azuki.core.parser.SimpleScenarioParser
 import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
+import com.anaplan.engineering.azuki.core.scenario.OracleScenario
+import com.anaplan.engineering.azuki.core.scenario.ScenarioWithQueries
+import com.anaplan.engineering.azuki.core.scenario.VerifiableScenario
 import com.anaplan.engineering.azuki.core.system.ActionFactory
+import com.anaplan.engineering.azuki.core.system.ActionGeneratorFactory
+import com.anaplan.engineering.azuki.core.system.CheckFactory
+import com.anaplan.engineering.azuki.core.system.QueryFactory
 import org.junit.Assert
 import org.slf4j.LoggerFactory
 import kotlin.test.expect
@@ -47,9 +53,8 @@ open class ScriptGenerationTestHelper<S : BuildableScenario<AF>, AF : ActionFact
 /**
  * Testing utilities for script generators.
  *
- * This class is flexible as to which kind of scenarios it takes as input - it can check testing for verifiable,
- * oracle, and query scenarios.  However, this means that it needs to take a `GenericScenarioGenerator` rather than a
- * `ScriptGenerationService`.
+ * This class is flexible as to which kind of scenarios it takes as input.  Typically, you'll want to instantiate one
+ * for each scenario type (verifiable, query, oracle) supported by your script generation adapter.
  */
 class ScriptGenerationTesting<S : BuildableScenario<*>>(
     val generator: (S) -> ScenarioScript,
@@ -98,3 +103,24 @@ class ScriptGenerationTesting<S : BuildableScenario<*>>(
         private val Log = LoggerFactory.getLogger(this::class.java.declaringClass)
     }
 }
+
+/**
+ * Creates a test helper for verifiable scenarios, given a way to parse them.
+ */
+fun <AF : ActionFactory, CF : CheckFactory> ScriptGenerationService<AF, CF, *, *, *, *>.createVerifiableTestHelper(
+    parser: ScenarioParser<VerifiableScenario<AF, CF>>
+) = ScriptGenerationTesting(::generateVerifiableScenario, parser)
+
+/**
+ * Creates a test helper for oracle scenarios, given a way to parse them.
+ */
+fun <AF : ActionFactory, QF : QueryFactory, AGF: ActionGeneratorFactory> ScriptGenerationService<AF, *, QF, AGF, *, *>.createOracleTestHelper(
+    parser: ScenarioParser<OracleScenario<AF, QF, AGF>>
+) = ScriptGenerationTesting(::generateOracleScenario, parser)
+
+/**
+ * Creates a test helper for query scenarios, given a way to parse them.
+ */
+fun <AF : ActionFactory, QF : QueryFactory> ScriptGenerationService<AF, *, QF, *, *, *>.createQueryTestHelper(
+    parser: ScenarioParser<ScenarioWithQueries<AF, QF>>
+) = ScriptGenerationTesting(::generateQueryScenario, parser)

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
@@ -56,7 +56,7 @@ open class ScriptGenerationTestHelper<S : BuildableScenario<AF>, AF : ActionFact
  * This class is flexible as to which kind of scenarios it takes as input.  Typically, you'll want to instantiate one
  * for each scenario type (verifiable, query, oracle) supported by your script generation adapter.
  */
-class ScriptGenerationTesting<S : BuildableScenario<*>>(
+open class ScriptGenerationTesting<S : BuildableScenario<*>>(
     val generator: (S) -> ScenarioScript,
     val parser: ScenarioParser<S> = SimpleScenarioParser(),
 ) {

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceStringFragmentsTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceStringFragmentsTest.kt
@@ -208,7 +208,7 @@ class ScriptGenerationServiceStringFragmentsTest {
 
     companion object {
 
-        fun generateAndRender(body: ScriptGenerationService<*, *, *, *, *, *>.() -> ScenarioScript) =
+        fun generateAndRender(body: ScriptGenerationService<*, *, *, *, *, *, *>.() -> ScenarioScript) =
             ScriptGenerationService.standalone.body().render().trim()
     }
 }

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceStringFragmentsTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceStringFragmentsTest.kt
@@ -24,9 +24,10 @@ class ScriptGenerationServiceStringFragmentsTest {
         """.trimIndent()) {
             generateAndRender {
                 given {
-                    fromFragments("thereIsAFoo(fooA)", "thereIsAFoo(fooB)")
+                    +"thereIsAFoo(fooA)"
+                    +"thereIsAFoo(fooB)"
                 }.whenever {
-                    fromFragments("deleteFoo(fooA)")
+                    +"deleteFoo(fooA)"
                 }.then {}.verifiableScenario
             }
         }
@@ -51,11 +52,13 @@ class ScriptGenerationServiceStringFragmentsTest {
         """.trimIndent()) {
             generateAndRender {
                 given {
-                    fromFragments("thereIsAFoo(fooA)", "thereIsAFoo(fooB)")
+                    +"thereIsAFoo(fooA)"
+                    +"thereIsAFoo(fooB)"
                 }.whenever {
-                    fromFragments("deleteFoo(fooA)")
+                    +"deleteFoo(fooA)"
                 }.then {
-                    fromFragments("fooExists(fooA)", "fooDoesNotExist(fooB)")
+                    +"fooExists(fooA)"
+                    +"fooDoesNotExist(fooB)"
                 }.verifiableScenario
             }
         }
@@ -80,11 +83,13 @@ class ScriptGenerationServiceStringFragmentsTest {
         """.trimIndent()) {
             generateAndRender {
                 given {
-                    fromFragments("thereIsAFoo(fooA)", "thereIsAFoo(fooB)")
+                    +"thereIsAFoo(fooA)"
+                    +"thereIsAFoo(fooB)"
                 }.whenever {
-                    fromFragments("deleteFoo(fooA)")
+                    +"deleteFoo(fooA)"
                 }.query {
-                    fromFragments("fooExists(fooA)", "fooExists(fooB)")
+                    +"fooExists(fooA)"
+                    +"fooExists(fooB)"
                 }.queryScenario
             }
         }
@@ -123,20 +128,23 @@ class ScriptGenerationServiceStringFragmentsTest {
         """.trimIndent()) {
             generateAndRender {
                 given {
-                    fromFragments("thereIsAFoo(fooA)")
+                    +"thereIsAFoo(fooA)"
                 }.generate {
-                    fromFragments("createFoo(fooB)")
-                    fromFragments("createFoo(fooC)")
+                    +"createFoo(fooB)"
+                    +"createFoo(fooC)"
                 }.generate {
-                    fromFragments("createBar(barA)")
+                    +"createBar(barA)"
                 }.whenever {
-                    fromFragments("deleteFoo(fooA)")
+                    +"deleteFoo(fooA)"
                 }.generate {
-                    fromFragments("deleteARandomFoo()")
+                    +"deleteARandomFoo()"
                 }.generate {
-                    fromFragments("deleteARandomBar()")
+                    +"deleteARandomBar()"
                 }.verify {
-                    fromFragments("fooExists(fooA)", "fooExists(fooB)", "fooExists(fooC)", "barExists(barA)")
+                    +"fooExists(fooA)"
+                    +"fooExists(fooB)"
+                    +"fooExists(fooC)"
+                    +"barExists(barA)"
                 }.oracleScenario
             }
         }
@@ -159,15 +167,15 @@ class ScriptGenerationServiceStringFragmentsTest {
         """.trimIndent()) {
             generateAndRender {
                 given {
-                    fromFragments("thereIsAFoo(fooA)")
+                    +"thereIsAFoo(fooA)"
                 }.generate {
                     // this can be left empty
                 }.whenever {
-                    fromFragments("deleteFoo(fooA)")
+                    +"deleteFoo(fooA)"
                 }.generate {
                     // this can be left empty
                 }.verify {
-                    fromFragments("fooExists(fooA)")
+                    +"fooExists(fooA)"
                 }.oracleScenario
             }
         }
@@ -192,15 +200,15 @@ class ScriptGenerationServiceStringFragmentsTest {
         """.trimIndent()) {
             generateAndRender {
                 given {
-                    fromFragments("thereIsAFoo(fooA)")
+                    +"thereIsAFoo(fooA)"
                 }.generateBlocks { /* this can be left empty */ }.whenever {
                     /* leaving this empty shouldn't cause whenever to disappear!
                      * it's needed to separate the given-generate and when-generate phases
                      */
                 }.generate {
-                    fromFragments("deleteARandomFoo()")
+                    +"deleteARandomFoo()"
                 }.verify {
-                    fromFragments("fooExists(fooA)")
+                    +"fooExists(fooA)"
                 }.oracleScenario
             }
         }

--- a/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/GraphScriptGeneratorTest.kt
+++ b/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/GraphScriptGeneratorTest.kt
@@ -6,6 +6,7 @@ import com.anaplan.engineering.azuki.graphs.dsl.GraphBuildableScenario
 import com.anaplan.engineering.azuki.graphs.dsl.GraphVerifiableScenario
 import com.anaplan.engineering.azuki.graphs.dsl.verifiableScenario
 import com.anaplan.engineering.azuki.script.generation.ScriptGenerationTesting
+import com.anaplan.engineering.azuki.script.generation.createVerifiableTestHelper
 import org.junit.Test
 
 class GraphScriptGeneratorTest {
@@ -13,22 +14,13 @@ class GraphScriptGeneratorTest {
     companion object {
         const val graphA = "graphA"
 
-        val ScenarioScriptingTestUtils = ScriptGenerationTesting(generator = {
-            GraphScriptGeneration.generateScenarioOfUnknownType(
-                it,
-                asVerifiable = { this as? GraphVerifiableScenario },
-            )
-        }, parser = object : SimpleScenarioParser<GraphBuildableScenario>() {
-            override val defaultImports: ScenarioParsingContext.() -> Unit = {
-                import("com.anaplan.engineering.azuki.graphs.dsl.*")
-                import("com.anaplan.engineering.azuki.graphs.*")
-            }
-        })
+        val VerifiableScenarioTesting =
+            GraphScriptGeneration.createVerifiableTestHelper(GraphScenarioParser<GraphVerifiableScenario>())
     }
 
     @Test
     fun graphWithEdges() {
-        ScenarioScriptingTestUtils.checkScenarioGeneration(verifiableScenario {
+        VerifiableScenarioTesting.checkScenarioGeneration(verifiableScenario {
             given {
                 thereIsAnUndirectedGraph(graphA) {
                     edge("a", "b")
@@ -42,7 +34,7 @@ class GraphScriptGeneratorTest {
 
     @Test
     fun graphWithParallelBlock() {
-        ScenarioScriptingTestUtils.checkScenarioGeneration(verifiableScenario {
+        VerifiableScenarioTesting.checkScenarioGeneration(verifiableScenario {
             given {
                 thereIsAnUndirectedGraph(graphA)
             }
@@ -61,7 +53,7 @@ class GraphScriptGeneratorTest {
 
     @Test
     fun directedGraph() {
-        ScenarioScriptingTestUtils.checkScenarioGeneration(verifiableScenario {
+        VerifiableScenarioTesting.checkScenarioGeneration(verifiableScenario {
             given {
                 thereIsADirectedGraph("graphA") {}
             }
@@ -69,5 +61,13 @@ class GraphScriptGeneratorTest {
                 hasVertexCount("graphA", 0)
             }
         })
+    }
+}
+
+class GraphScenarioParser<S : GraphBuildableScenario> : SimpleScenarioParser<S>() {
+
+    override val defaultImports: ScenarioParsingContext.() -> Unit = {
+        import("com.anaplan.engineering.azuki.graphs.dsl.*")
+        import("com.anaplan.engineering.azuki.graphs.*")
     }
 }

--- a/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/GraphScriptGeneratorTest.kt
+++ b/graphs/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/GraphScriptGeneratorTest.kt
@@ -5,7 +5,6 @@ import com.anaplan.engineering.azuki.core.parser.SimpleScenarioParser
 import com.anaplan.engineering.azuki.graphs.dsl.GraphBuildableScenario
 import com.anaplan.engineering.azuki.graphs.dsl.GraphVerifiableScenario
 import com.anaplan.engineering.azuki.graphs.dsl.verifiableScenario
-import com.anaplan.engineering.azuki.script.generation.ScriptGenerationTesting
 import com.anaplan.engineering.azuki.script.generation.createVerifiableTestHelper
 import org.junit.Test
 

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
@@ -12,7 +12,8 @@ val TicTacToeScriptGeneration = ScriptGenerationService.new(TicTacToeScriptGener
     TicTacToeScriptGenerationCheckFactory,
     ::TicTacToeDeclarationState).withEnvironmentFactory(::TicTacToeGenerationEnvironment)
     .withActionGeneratorFactory(TicTacToeScriptGenerationActionGeneratorFactory)
-    .withQueryFactories(TicTacToeScriptGenerationQueryQueryFactory, TicTacToeScriptGenerationVerificationQueryFactory)
+    .withQueryFactory(TicTacToeScriptGenerationQueryQueryFactory)
+    .withVerifyFactory(TicTacToeScriptGenerationVerificationQueryFactory)
     .build()
 
 // None of the declaration builders for TicTacToe use the environment:

--- a/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
+++ b/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
@@ -2,10 +2,10 @@ package com.anaplan.engineering.azuki.tictactoe.adapter.scriptgen
 
 import com.anaplan.engineering.azuki.core.parser.ScenarioParsingContext
 import com.anaplan.engineering.azuki.core.parser.SimpleScenarioParser
-import com.anaplan.engineering.azuki.script.generation.ScriptGenerationTesting
+import com.anaplan.engineering.azuki.script.generation.createOracleTestHelper
+import com.anaplan.engineering.azuki.script.generation.createVerifiableTestHelper
 import com.anaplan.engineering.azuki.tictactoe.dsl.TicTacToeBuildableScenario
 import com.anaplan.engineering.azuki.tictactoe.dsl.TicTacToeOracleScenario
-import com.anaplan.engineering.azuki.tictactoe.dsl.TicTacToeQueryScenario
 import com.anaplan.engineering.azuki.tictactoe.dsl.TicTacToeVerifiableScenario
 import com.anaplan.engineering.azuki.tictactoe.dsl.oracleScenario
 import com.anaplan.engineering.azuki.tictactoe.dsl.verifiableScenario
@@ -22,15 +22,10 @@ class TicTacToeScriptGeneratorTest {
         const val X = "X"
         const val O = "O"
 
-        val ScenarioScriptingTestUtils = ScriptGenerationTesting(generator = {
-            TicTacToeScriptGeneration.generateScenarioOfUnknownType(it,
-                { this as? TicTacToeVerifiableScenario },
-                { this as? TicTacToeOracleScenario },
-                { this as? TicTacToeQueryScenario })
-        }, parser = object : SimpleScenarioParser<TicTacToeBuildableScenario>() {
-
-            override val defaultImports: ScenarioParsingContext.() -> Unit = { import(*ticTacToeStandardImports) }
-        })
+        val VerifiableScenarioTesting =
+            TicTacToeScriptGeneration.createVerifiableTestHelper(TicTacToeScenarioParser<TicTacToeVerifiableScenario>())
+        val OracleScenarioTesting =
+            TicTacToeScriptGeneration.createOracleTestHelper(TicTacToeScenarioParser<TicTacToeOracleScenario>())
 
         private fun renderedThenElements(scenario: TicTacToeVerifiableScenario): List<String> =
             TicTacToeScriptGeneration.generateVerifiableScenario(scenario).then.elements.map { it.render() }
@@ -168,7 +163,7 @@ class TicTacToeScriptGeneratorTest {
                 boardHasToken(gameA, X, 3 to 3)
             }
         }
-        ScenarioScriptingTestUtils.assertScenariosProduceSameScript(composed, decomposed)
+        VerifiableScenarioTesting.assertScenariosProduceSameScript(composed, decomposed)
     }
 
     @Test
@@ -206,7 +201,7 @@ class TicTacToeScriptGeneratorTest {
 
     @Test
     fun moves() {
-        ScenarioScriptingTestUtils.checkScenarioGeneration(verifiableScenario {
+        VerifiableScenarioTesting.checkScenarioGeneration(verifiableScenario {
             given {
                 thereIsAPlayOrder(orderA, O, X)
                 thereIsAGame(gameA, orderA, """
@@ -228,7 +223,7 @@ class TicTacToeScriptGeneratorTest {
 
     @Test
     fun movesAndOnlyTheMoves() {
-        ScenarioScriptingTestUtils.checkScenarioGeneration(verifiableScenario {
+        VerifiableScenarioTesting.checkScenarioGeneration(verifiableScenario {
             given {
                 thereIsAPlayOrder(orderA, O, X)
                 thereIsAGame(gameA, orderA, """
@@ -253,7 +248,7 @@ class TicTacToeScriptGeneratorTest {
 
     @Test
     fun exampleOracleScenario() {
-        ScenarioScriptingTestUtils.checkScenarioGeneration(oracleScenario {
+        OracleScenarioTesting.checkScenarioGeneration(oracleScenario {
             generate {
                 createPlayOrder("orderA")
                 createPlayOrder("orderB")
@@ -281,4 +276,9 @@ class TicTacToeScriptGeneratorTest {
             }
         })
     }
+}
+
+class TicTacToeScenarioParser<S: TicTacToeBuildableScenario> : SimpleScenarioParser<S>() {
+
+    override val defaultImports: ScenarioParsingContext.() -> Unit = { import(*ticTacToeStandardImports) }
 }

--- a/tictactoe/script-runner/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/scriptrunner/TicTacToeSystemWriter.kt
+++ b/tictactoe/script-runner/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/scriptrunner/TicTacToeSystemWriter.kt
@@ -1,6 +1,5 @@
 package com.anaplan.engineering.azuki.tictactoe.scriptrunner
 
-import com.anaplan.engineering.azuki.script.generation.RunnableScenarioClassGenerator
 import com.anaplan.engineering.azuki.script.generation.ScriptGenerationSystemWriter
 import com.anaplan.engineering.azuki.tictactoe.adapter.api.*
 import com.anaplan.engineering.azuki.tictactoe.adapter.scriptgen.TicTacToeRunnableScenarioClassGenerator


### PR DESCRIPTION
This PR proposes a few fixups to the work in the last PR:

- Delete `generateScenarioWithUnknownType`; it was only being used in testing code, and can easily be expressed by just sub-instancing the scenario testing utility for the various different scenario types needed.  (Added some helper code to make this easier.)
- Add `@DslMarker` to the builder classes (this prevents, for instance, writing `given { given { .. } }`)
- Replace `fromFragments` and `fromElements` with unary `+` (which is a little bit cryptic, but aligns with the practice established by the example in https://kotlinlang.org/docs/type-safe-builders.html and reads fairly well)
- Split `QF` into `QQF` (query-query) and `VQF` (verify-query), thereby allowing the two factories to be specified separately
- Some classes that were either closed or abstract are now open, primarily because we used to use them as `object`s and would like to continue doing so (instead of having to use `val`s).

Some things that _didn't_ make it into this PR (and why):

- I considered adding syntactic sugar to write `given{}.whenever{}.then{}.verifiableScenario` as `generateVerifiableScenario{ given{}.whenever{}.then{} }`, but decided this was too misleading - while it's closer to the shape of an Azuki scenario, the builder API is fluent to enforce rigidity rather than fully block-based (see the `.`s between each stage!).  Maybe it should've been block-based, but I like it using the type system to enforce structure :)
- I also considered making it possible to mix explicit script fragments and those derived from bits of azuki scenario, but ran into a brick wall because we really want to wait until all the declarable actions (for a `given`) and checks (for a `then`) are in before we scriptify, to allow proper composition of the two.