### PR TITLE
Add workaround for KtLint U+FEFF issue

### DIFF
--- a/azuki-script-formatter/src/main/kotlin/com/anaplan/engineering/azuki/script/formatter/ScenarioFormatter.kt
+++ b/azuki-script-formatter/src/main/kotlin/com/anaplan/engineering/azuki/script/formatter/ScenarioFormatter.kt
@@ -24,16 +24,21 @@ object ScenarioFormatter {
 
     @JvmStatic
     fun formatScenario(scenarioText: String): String {
-        val code = Code.fromSnippet(scenarioText, true)
-
-        return ruleEngine.format(code) { error ->
-            if (error.canBeAutoCorrected) {
-                AutocorrectDecision.ALLOW_AUTOCORRECT
-            } else {
-                AutocorrectDecision.NO_AUTOCORRECT
-            }
-        }
+        // Workaround for https://github.com/pinterest/ktlint/issues/3220: KtLint assumes there is either no U+FEFF,
+        // or the first one is a BOM (ie at the start of the file).  If the first U+FEFF turns up elsewhere, it deletes
+        // it but doesn't reinsert it.  So we just add a BOM in all cases to force the correct behavior.
+        val hadBom = scenarioText.startsWith(BOM)
+        val code = Code.fromSnippet(if (hadBom) scenarioText else "${BOM}$scenarioText", true)
+        val formatted = runKtLint(code)
+        // make sure we drop the BOM if it wasn't one we spliced in
+        return if (hadBom) formatted else formatted.removePrefix(BOM)
     }
+
+    private fun runKtLint(code: Code) = ruleEngine.format(code) { error ->
+        if (error.canBeAutoCorrected) AutocorrectDecision.ALLOW_AUTOCORRECT else AutocorrectDecision.NO_AUTOCORRECT
+    }
+
+    const val BOM = "\uFEFF"
 }
 
 fun main(args: Array<String>) {

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceBomTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceBomTest.kt
@@ -1,0 +1,67 @@
+package com.anaplan.engineering.azuki.script.generation
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.*
+
+/**
+ * Tests some BOM corner cases in script generation and formatting.
+ */
+@RunWith(Parameterized::class)
+class ScriptGenerationServiceBomTest(
+    private var name: String, private var formatter: Formatter, private var prefix: String
+) {
+
+    @Test
+    fun test() {
+
+        expect(prefix + expected, "problem with BOMs in case $name") {
+            ScriptGenerationService.standalone.bomScenario().render({
+                formatter = if (prefix.isNotEmpty()) {
+                    // slipstream in the prefix
+                    Formatter { this@ScriptGenerationServiceBomTest.formatter.format(prefix + it) }
+                } else {
+                    this@ScriptGenerationServiceBomTest.formatter
+                }
+            }).trim()
+        }
+    }
+
+    companion object {
+
+        @Parameterized.Parameters(name = "{0}")
+        @JvmStatic
+        fun data(): Collection<Array<Any>> = listOf(
+            arrayOf("unformatted", Formatter.None, ""),
+            arrayOf("formatted", Formatter.Full, ""),
+            arrayOf("unformatted with BOM", Formatter.None, BOM),
+            arrayOf("formatted with BOM", Formatter.Full, BOM),
+        )
+
+        const val BOM = "\uFEFF"
+        val expected by lazy {
+            """
+            verifiableScenario {
+                given {
+                    thisHasABOM("${BOM}atTheStart")
+                    thisHasABOM("in${BOM}TheMiddle")
+                    thisHasABOM("atTheEnd${BOM}")
+                    thisHasABOM("色は匂えど${BOM}散りぬるを")
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+            """.trimIndent()
+        }
+
+        fun ScriptGenerationService<*, *, *, *, *, *, *>.bomScenario(): ScenarioScript = given {
+            +"        thisHasABOM(\"${BOM}atTheStart\")"
+            +"        thisHasABOM(\"in${BOM}TheMiddle\")"
+            +"        thisHasABOM(\"atTheEnd${BOM}\")"
+            +"        thisHasABOM(\"色は匂えど${BOM}散りぬるを\")"
+        }.whenever {}.then {
+            +"        everythingIsOkay()"
+        }.verifiableScenario
+    }
+}

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceStringFragmentsTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceStringFragmentsTest.kt
@@ -214,9 +214,11 @@ class ScriptGenerationServiceStringFragmentsTest {
         }
     }
 
+
     companion object {
 
-        fun generateAndRender(body: ScriptGenerationService<*, *, *, *, *, *, *>.() -> ScenarioScript) =
-            ScriptGenerationService.standalone.body().render().trim()
+        fun generateAndRender(
+            body: ScriptGenerationService<*, *, *, *, *, *, *>.() -> ScenarioScript
+        ) = ScriptGenerationService.standalone.body().render().trim()
     }
 }


### PR DESCRIPTION
Works around the issue described in [this KtLint issue](https://github.com/pinterest/ktlint/issues/3220).

The workaround is simple if inelegant: we just always make sure there's a BOM before things go into KtLint, thereby forcing KtLint onto the happy path where it sees the BOM, removes it, and adds it back in.  We then remove the BOM again, if we were the ones who added it.  (So, writ large, we add a BOM, KtLint removes it, KtLint puts it back, we remove it again...)

It's worth noting that we use an old version of KtLint (1.4.0), but the bug seems to be still in place in 1.8.0.