### PR TITLE
Add ConcurrentModificationError trap to TaskWrapper

### DIFF
--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
@@ -92,7 +92,7 @@ private class LogAndCaptureOutputStream(
 
     override fun write(b: Int) {
         if (b.toChar() == '\n') {
-            logOutAndClear()
+            logAndClearBuffer()
         } else {
             buffer.add(b.toByte())
         }
@@ -105,17 +105,18 @@ private class LogAndCaptureOutputStream(
 
     override fun close() {
         if (buffer.isNotEmpty()) {
-            logOutAndClear()
+            logAndClearBuffer()
         }
         capture.close()
     }
 
-    private fun logOutAndClear() {
+    private fun logAndClearBuffer() {
         try {
             log(String(buffer.toByteArray()))
             buffer.clear()
-        } catch (e: ConcurrentModificationException) {
-            Log.warn("Unable to capture stdout for task: ${e.message}")
+        } catch (e: Exception) {
+            Log.warn("Unable to capture stdout for task: {}", e.message)
+            Log.warn("Stacktrace:\n{}", e.stackTraceToString())
         }
     }
 

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
@@ -79,9 +79,7 @@ internal class TaskWrapper<
             } else {
                 "${this}ns"
             }
-
     }
-
 }
 
 private class LogAndCaptureOutputStream(
@@ -94,8 +92,7 @@ private class LogAndCaptureOutputStream(
 
     override fun write(b: Int) {
         if (b.toChar() == '\n') {
-            log(String(buffer.toByteArray()))
-            buffer.clear()
+            logOutAndClear()
         } else {
             buffer.add(b.toByte())
         }
@@ -108,9 +105,22 @@ private class LogAndCaptureOutputStream(
 
     override fun close() {
         if (buffer.isNotEmpty()) {
-            log(String(buffer.toByteArray()))
-            buffer.clear()
+            logOutAndClear()
         }
         capture.close()
+    }
+
+    private fun logOutAndClear() {
+        try {
+            log(String(buffer.toByteArray()))
+            buffer.clear()
+        } catch (e: ConcurrentModificationException) {
+            Log.warn("Unable to capture stdout for task: ${e.message}")
+        }
+    }
+
+    companion object {
+
+        private val Log = LoggerFactory.getLogger(LogAndCaptureOutputStream::class.java)
     }
 }

--- a/azuki-core/src/test/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapperTest.kt
+++ b/azuki-core/src/test/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapperTest.kt
@@ -1,0 +1,57 @@
+package com.anaplan.engineering.azuki.core.runner
+
+import com.anaplan.engineering.azuki.core.scenario.BuildableScenario
+import com.anaplan.engineering.azuki.core.scenario.VerifiableScenario
+import com.anaplan.engineering.azuki.core.system.Action
+import com.anaplan.engineering.azuki.core.system.ActionFactory
+import com.anaplan.engineering.azuki.core.system.CheckFactory
+import com.anaplan.engineering.azuki.core.system.Implementation
+import com.anaplan.engineering.azuki.core.system.NoActionGeneratorFactory
+import com.anaplan.engineering.azuki.core.system.NoQueryFactory
+import com.anaplan.engineering.azuki.core.system.NoSystemDefaults
+import com.anaplan.engineering.azuki.core.system.SystemFactory
+import kotlin.concurrent.thread
+import kotlin.test.*
+
+class TaskWrapperTest {
+
+    @Test
+    fun taskWrapperCapturesStdout() {
+        val wrapper = TaskWrapper(TaskType.Verify, DummyImplementation) {
+            repeat(10) { println("hello, world") }
+        }
+
+        val result = wrapper.run(DummyScenario)
+
+        assertEquals("hello, world\n".repeat(10), result.log.output)
+    }
+
+    @Test
+    fun taskWrapperCapturesStderr() {
+        val wrapper = TaskWrapper(TaskType.Verify, DummyImplementation) {
+            repeat(10) { System.err.println("hello, world") }
+        }
+
+        val result = wrapper.run(DummyScenario)
+
+        assertEquals("hello, world\n".repeat(10), result.log.error)
+    }
+
+    // TODO: add concurrency tests here
+
+    object DummyScenario : BuildableScenario<ActionFactory> {
+        override fun declarations(actionFactory: ActionFactory) = listOf<Action>()
+        override fun commands(actionFactory: ActionFactory) = listOf<Action>()
+    }
+
+    object DummyImplementation : Implementation<ActionFactory, CheckFactory, NoQueryFactory, NoActionGeneratorFactory, NoSystemDefaults> {
+        override val name = "dummy"
+        override val implementationDefaults = NoSystemDefaults
+
+        override fun createSystemFactory(systemDefaults: NoSystemDefaults): SystemFactory<ActionFactory, CheckFactory, NoQueryFactory, NoActionGeneratorFactory, NoSystemDefaults, *> {
+            TODO("Not yet implemented")
+        }
+
+        override val versionFilter = Implementation.VersionFilter.DefaultVersionFilter
+    }
+}


### PR DESCRIPTION
We've started seeing these appear on Azuki runs internally, and this is a stopgap solution until we can further diagnose the problem.