### PR TITLE
Close capture channels after redirecting away from them

### DIFF
--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
@@ -61,10 +61,11 @@ internal class TaskWrapper<
             Log.error("System error running task type=${taskType}", t)
             throw t
         } finally {
-            outCapture.close()
-            errCapture.close()
             System.setOut(out)
             System.setErr(err)
+            // Try to avoid stdout/stderr pointing to closed streams by delaying closing them:
+            outCapture.close()
+            errCapture.close()
         }
     }
 


### PR DESCRIPTION
Instead of closing the TaskWrapper capture channels _before_ redirecting from them back to stdout/stderr, do the redirect first.

This is an attempt to make the TaskWrapper a little more robust against strange edge cases in how its output redirection works.  Unfortunately, since we haven't been able to get a convincing MWE for the CME issue, it's a bit of a 'cargo-cult' solution to the problem... but it's something we should probably do anyway.