### PR TITLE
Minor refactors to script rendering

### DIFF
--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
@@ -169,7 +169,7 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     /**
      * Shorthand for rendering each of the block's elements separately.
      */
-    fun renderedElements(ctx: RenderContext = RenderContext()) = elements.map { it.render(ctx) }
+    fun renderElements(ctx: RenderContext = RenderContext()) = elements.map { it.render(ctx) }
 
     /**
      * A script block with the same header and contents, but with `isEmpty` forced to false.

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
@@ -121,17 +121,17 @@ data class OracleScenarioScript(
 /**
  * A component in a DSL script that is being generated.
  */
-interface ScriptElement {
+fun interface ScriptElement {
 
     /**
      * Is the element empty and therefore safe to skip?
      */
-    val isEmpty: Boolean
+    val isEmpty: Boolean get() = false
 
     /**
      * Renders the contents of the script element to a string with the given context.
      */
-    fun render(ctx: RenderContext = RenderContext()): String
+    fun render(ctx: RenderContext): String
 }
 
 /**
@@ -165,6 +165,11 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     override fun render(ctx: RenderContext) = with(ctx) {
         listOf("$indent$header {", inner.render(nextIndentLevel), "$indent}").joinToString("\n")
     }
+
+    /**
+     * Shorthand for rendering each of the block's elements separately.
+     */
+    fun renderedElements(ctx: RenderContext = RenderContext()) = elements.map { it.render(ctx) }
 
     /**
      * A script block with the same header and contents, but with `isEmpty` forced to false.

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
@@ -57,8 +57,8 @@ open class ScriptGenerationTestHelper<S : BuildableScenario<AF>, AF : ActionFact
  * This class is flexible as to which kind of scenarios it takes as input.  Typically, you'll want to instantiate one
  * for each scenario type (verifiable, query, oracle) supported by your script generation adapter.
  */
-open class ScriptGenerationTesting<S : BuildableScenario<*>>(
-    val generator: (S) -> ScenarioScript,
+open class ScriptGenerationTesting<S : BuildableScenario<*>, O : ScenarioScript>(
+    val generator: (S) -> O,
     val parser: ScenarioParser<S> = SimpleScenarioParser(),
 ) {
 
@@ -74,7 +74,7 @@ open class ScriptGenerationTesting<S : BuildableScenario<*>>(
      *
      * Returns the regenerated scenario script, so that it can be used in further assertions.
      */
-    fun checkScenarioGeneration(scenario: S, initContext: ScenarioParsingContext.() -> Unit = {}): ScenarioScript {
+    fun checkScenarioGeneration(scenario: S, initContext: ScenarioParsingContext.() -> Unit = {}): O {
         Log.debug("Generating script")
         val generatedScript = generator(scenario)
         val renderedGeneratedScript = generatedScript.render()
@@ -87,7 +87,7 @@ open class ScriptGenerationTesting<S : BuildableScenario<*>>(
         val renderedRegeneratedScript = regeneratedScript.render()
         Log.debug("Regenerated:\n{}", renderedRegeneratedScript)
 
-        expect(renderedRegeneratedScript) { renderedGeneratedScript }
+        assertEquals(renderedRegeneratedScript, renderedGeneratedScript)
 
         return regeneratedScript
     }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
@@ -57,8 +57,8 @@ open class ScriptGenerationTestHelper<S : BuildableScenario<AF>, AF : ActionFact
  * This class is flexible as to which kind of scenarios it takes as input.  Typically, you'll want to instantiate one
  * for each scenario type (verifiable, query, oracle) supported by your script generation adapter.
  */
-open class ScriptGenerationTesting<S : BuildableScenario<*>, O : ScenarioScript>(
-    val generator: (S) -> O,
+open class ScriptGenerationTesting<S : BuildableScenario<*>, SCRIPT : ScenarioScript>(
+    val generator: (S) -> SCRIPT,
     val parser: ScenarioParser<S> = SimpleScenarioParser(),
 ) {
 
@@ -74,7 +74,7 @@ open class ScriptGenerationTesting<S : BuildableScenario<*>, O : ScenarioScript>
      *
      * Returns the regenerated scenario script, so that it can be used in further assertions.
      */
-    fun checkScenarioGeneration(scenario: S, initContext: ScenarioParsingContext.() -> Unit = {}): O {
+    fun checkScenarioGeneration(scenario: S, initContext: ScenarioParsingContext.() -> Unit = {}): SCRIPT {
         Log.debug("Generating script")
         val generatedScript = generator(scenario)
         val renderedGeneratedScript = generatedScript.render()

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationTestHelper.kt
@@ -13,6 +13,7 @@ import com.anaplan.engineering.azuki.core.system.CheckFactory
 import com.anaplan.engineering.azuki.core.system.QueryFactory
 import org.junit.Assert
 import org.slf4j.LoggerFactory
+import kotlin.test.assertEquals
 import kotlin.test.expect
 
 @Deprecated("Use ScriptGenerationTesting")

--- a/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
+++ b/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
@@ -28,7 +28,7 @@ class TicTacToeScriptGeneratorTest {
             TicTacToeScriptGeneration.createOracleTestHelper(TicTacToeScenarioParser<TicTacToeOracleScenario>())
 
         private fun renderedThenElements(scenario: TicTacToeVerifiableScenario): List<String> =
-            TicTacToeScriptGeneration.generateVerifiableScenario(scenario).then.elements.map { it.render() }
+            TicTacToeScriptGeneration.generateVerifiableScenario(scenario).then.renderedElements()
 
         private const val TRIPLE = "\"\"\""
     }

--- a/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
+++ b/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
@@ -28,7 +28,7 @@ class TicTacToeScriptGeneratorTest {
             TicTacToeScriptGeneration.createOracleTestHelper(TicTacToeScenarioParser<TicTacToeOracleScenario>())
 
         private fun renderedThenElements(scenario: TicTacToeVerifiableScenario): List<String> =
-            TicTacToeScriptGeneration.generateVerifiableScenario(scenario).then.renderedElements()
+            TicTacToeScriptGeneration.generateVerifiableScenario(scenario).then.renderElements()
 
         private const val TRIPLE = "\"\"\""
     }


### PR DESCRIPTION
- Make `ScriptElement` a `fun interface`.  This means that `isEmpty` must default to `false` and `render` can no longer default its `RenderContext`, but also makes producing `ScriptElement`s more lightweight.
- Add a shorthand, `renderedElements`, to map `render` over all the `elements` of a `ScriptBlock`.  This is mostly useful in tests.
- Make `ScriptGenerationTesting` parametric in its output type, avoiding the need to cast `ScenarioScript` to `VerifiableScenarioScript` et al.