### PR TITLE
Thread ScriptElements through scriptgen interfaces

### DIFF
--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
@@ -129,6 +129,11 @@ interface ScriptElement {
     val isEmpty: Boolean
 
     /**
+     * Is the element safe to lay out horizontally?
+     */
+    val isHorizontal: Boolean get() = false
+
+    /**
      * Renders the contents of the script element to a string with the given context.
      */
     fun render(ctx: RenderContext = RenderContext()): String
@@ -143,9 +148,58 @@ interface ScriptElement {
  */
 data class ScriptStringFragment(val fragment: String) : ScriptElement {
 
-    override val isEmpty: Boolean = fragment.isBlank()
+    override val isEmpty = fragment.isBlank()
+    override val isHorizontal = '\n' !in fragment
 
     override fun render(ctx: RenderContext) = fragment
+}
+
+/**
+ * A script element representing a function call.
+ */
+data class ScriptFunction(val name: String, val args: List<ScriptElement>) : ScriptElement {
+
+    override val isEmpty = false
+
+    override fun render(ctx: RenderContext) = buildString {
+        append("${ctx.indent}$name(")
+
+        val anyVertical = args.any { !it.isHorizontal }
+        if (anyVertical) {
+            appendLine()
+        }
+
+        args.forEachIndexed { i, arg ->
+            val wasHorizontal = args.getOrNull(i - 1)?.isHorizontal
+
+            val joiner = when {
+                i == 0 -> ""
+                arg.isHorizontal && wasHorizontal == true -> ", "
+                // force a linebreak when transitioning from horizontal to vertical, or between vertical, arguments
+                else -> ",\n"
+            }
+
+            val argCtx = if (arg.isHorizontal) {
+                // we'll handle indenting horizontally laid-out arguments
+                ctx.copy(indentLevel = 0)
+            } else {
+                ctx.nextIndentLevel
+            }
+
+            append(joiner)
+            val startOfHorizontalRun = anyVertical && arg.isHorizontal && wasHorizontal != true
+            if (startOfHorizontalRun) {
+                append(ctx.nextIndentLevel.indent)
+            }
+            append(arg.render(argCtx))
+        }
+
+        if (anyVertical) {
+            append(",\n${ctx.indent})")
+        } else {
+            append(")")
+        }
+    }
 }
 
 /**
@@ -156,6 +210,7 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     constructor(header: String, contents: List<ScriptElement>) : this(header, ScriptElementList(contents))
 
     override val isEmpty get() = inner.isEmpty
+    override val isHorizontal = false
 
     /**
      * Gets the script elements contained within this block.

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScenarioScript.kt
@@ -129,15 +129,40 @@ interface ScriptElement {
     val isEmpty: Boolean
 
     /**
-     * Is the element safe to lay out horizontally?
+     * Which way should this element be oriented if rendered into a list?
      */
-    val isHorizontal: Boolean get() = false
+    val orientation: Orientation get() = Orientation.Horizontal
+
+    /**
+     * Renders initial indentation for this element.
+     * Override to remove or otherwise alter initial indentation.
+     */
+    fun initialIndent(ctx: RenderContext) = ctx.indent
 
     /**
      * Renders the contents of the script element to a string with the given context.
      */
     fun render(ctx: RenderContext = RenderContext()): String
+
+    /**
+     * Orientation of script elements in lists and similar constructs.
+     */
+    enum class Orientation {
+        /**
+         * Should be laid out horizontally in lists.
+         */
+        Horizontal,
+
+        /**
+         * Should be laid out vertically in lists.
+         */
+        Vertical;
+
+        val isHorizontal get() = this == Horizontal
+        val isVertical get() = this == Vertical
+    }
 }
+
 
 /**
  * A raw string fragment as a script element.
@@ -149,8 +174,11 @@ interface ScriptElement {
 data class ScriptStringFragment(val fragment: String) : ScriptElement {
 
     override val isEmpty = fragment.isBlank()
-    override val isHorizontal = '\n' !in fragment
+    override val orientation =
+        if ('\n' in fragment) ScriptElement.Orientation.Vertical else ScriptElement.Orientation.Horizontal
 
+    // don't initially indent string fragments, in case they have their own indentation or are sensitive to it
+    override fun initialIndent(ctx: RenderContext) = ""
     override fun render(ctx: RenderContext) = fragment
 }
 
@@ -160,44 +188,52 @@ data class ScriptStringFragment(val fragment: String) : ScriptElement {
 data class ScriptFunction(val name: String, val args: List<ScriptElement>) : ScriptElement {
 
     override val isEmpty = false
+    override val orientation: ScriptElement.Orientation = if (args.any { it.orientation.isVertical }) {
+        ScriptElement.Orientation.Vertical
+    } else {
+        ScriptElement.Orientation.Horizontal
+    }
 
     override fun render(ctx: RenderContext) = buildString {
-        append("${ctx.indent}$name(")
-
-        val anyVertical = args.any { !it.isHorizontal }
-        if (anyVertical) {
+        append("$name(")
+        if (orientation.isVertical) {
+            // put arguments on separate lines to the opening and closing parens
             appendLine()
         }
 
-        args.forEachIndexed { i, arg ->
-            val wasHorizontal = args.getOrNull(i - 1)?.isHorizontal
+        var last: ScriptElement? = null
+        for (arg in args) {
+            val argCtx = ctx.nextIndentLevel
 
-            val joiner = when {
-                i == 0 -> ""
-                arg.isHorizontal && wasHorizontal == true -> ", "
-                // force a linebreak when transitioning from horizontal to vertical, or between vertical, arguments
-                else -> ",\n"
-            }
-
-            val argCtx = if (arg.isHorizontal) {
-                // we'll handle indenting horizontally laid-out arguments
-                ctx.copy(indentLevel = 0)
-            } else {
-                ctx.nextIndentLevel
-            }
-
-            append(joiner)
-            val startOfHorizontalRun = anyVertical && arg.isHorizontal && wasHorizontal != true
-            if (startOfHorizontalRun) {
-                append(ctx.nextIndentLevel.indent)
-            }
+            append(argumentJoiner(last, arg))
+            append(argumentIndent(last, arg, argCtx))
             append(arg.render(argCtx))
+
+            last = arg
         }
 
-        if (anyVertical) {
-            append(",\n${ctx.indent})")
-        } else {
-            append(")")
+        if (orientation.isVertical) {
+            // add a trailing comma whenever rendering a vertical argument list
+            append(",\n${ctx.indent}")
+        }
+        append(")")
+    }
+
+    private fun argumentJoiner(last: ScriptElement?, arg: ScriptElement) = when {
+        last == null -> ""
+        arg.orientation.isHorizontal && last.orientation.isHorizontal -> ", "
+        // force a linebreak when transitioning from horizontal to vertical, or between vertical, arguments
+        else -> ",\n"
+    }
+
+    private fun argumentIndent(last: ScriptElement?, arg: ScriptElement, argCtx: RenderContext): String {
+        val lastVerticalIfPresent = last == null || last.orientation.isVertical
+        val atHorizontalRunStart = orientation.isVertical && arg.orientation.isHorizontal && lastVerticalIfPresent
+        return when (arg.orientation) {
+            // always apply indentation at the start of runs of horizontal arguments
+            ScriptElement.Orientation.Horizontal -> if (atHorizontalRunStart) argCtx.indent else ""
+            // apply whatever indentation vertical arguments need
+            ScriptElement.Orientation.Vertical -> arg.initialIndent(argCtx)
         }
     }
 }
@@ -210,7 +246,7 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     constructor(header: String, contents: List<ScriptElement>) : this(header, ScriptElementList(contents))
 
     override val isEmpty get() = inner.isEmpty
-    override val isHorizontal = false
+    override val orientation = ScriptElement.Orientation.Vertical
 
     /**
      * Gets the script elements contained within this block.
@@ -218,7 +254,9 @@ data class ScriptBlock(val header: String, val inner: ScriptElement) : ScriptEle
     val elements get() = if (inner is ScriptElementList<*>) inner.elements else listOf(inner)
 
     override fun render(ctx: RenderContext) = with(ctx) {
-        listOf("$indent$header {", inner.render(nextIndentLevel), "$indent}").joinToString("\n")
+        val innerCtx = nextIndentLevel
+        val body = inner.takeUnless { it.isEmpty }?.let { it.initialIndent(innerCtx) + it.render(innerCtx) }
+        listOfNotNull("$header {", body, "$indent}").joinToString("\n")
     }
 
     /**
@@ -243,8 +281,14 @@ data class ScriptElementList<E : ScriptElement>(val elements: List<E>) : ScriptE
     constructor(vararg elements: E) : this(listOf(*elements))
 
     override val isEmpty get() = elements.all { it.isEmpty }
+    override val orientation = ScriptElement.Orientation.Vertical
 
-    override fun render(ctx: RenderContext) = elements.filterNot { it.isEmpty }.joinToString("\n") { it.render(ctx) }
+    // distribute any initial indentation to the script elements
+    override fun initialIndent(ctx: RenderContext) = ""
+
+    override fun render(ctx: RenderContext) = elements.filterNot { it.isEmpty }.joinToString("\n") {
+        it.initialIndent(ctx) + it.render(ctx)
+    }
 
     operator fun plus(other: ScriptElementList<E>) = ScriptElementList(elements + other.elements)
 }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationAction.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationAction.kt
@@ -6,6 +6,15 @@ import com.anaplan.engineering.azuki.core.system.ParallelAction
 interface ScriptGenerationAction<in E : ScriptGenerationEnvironment> : Action {
 
     fun getActionScript(environment: E): String
+
+    /**
+     * As `getActionScript`, but returns a renderable script element instead of a string.
+     *
+     * By default, this returns an element that wraps the contents of `getActionScript`.
+     * Override this for more control over the script generation of an action.
+     * (If doing so, consider making `getActionScript` call the `render` method of the script element for consistency.)
+     */
+    fun getActionScriptElement(environment: E): ScriptElement = ScriptStringFragment(getActionScript(environment))
 }
 
 class ScriptGenerationParallelAction<in E : ScriptGenerationEnvironment>(actions: List<List<ScriptGenerationAction<E>>>) :

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationActionGenerator.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationActionGenerator.kt
@@ -5,4 +5,14 @@ import com.anaplan.engineering.azuki.core.system.ActionGenerator
 fun interface ScriptGenerationActionGenerator: ActionGenerator {
 
     fun getActionGeneratorScript(): String
+
+    /**
+     * As `getActionGeneratorScript`, but returns a renderable script element instead of a string.
+     *
+     * By default, this returns an element that wraps the contents of `getActionGeneratorScript`.
+     * Override this for more control over the script generation of an action.
+     * (If doing so, consider making `getActionGeneratorScript` call the `render` method of the script element for
+     * consistency.)
+     */
+    fun getActionGeneratorScriptElement(): ScriptElement = ScriptStringFragment(getActionGeneratorScript())
 }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationBuilders.kt
@@ -121,7 +121,7 @@ class WheneverBuilder<out AF : ActionFactory, E : ScriptGenerationEnvironment>(v
 
     override fun fromScenario(scenario: BuildableScenario<in AF>) = fromActions(scenario.commands(actionFactory))
 
-    override val builtScriptElements get() = commands.map { ScriptStringFragment(it.getActionScript(environment)) }
+    override val builtScriptElements get() = commands.map { it.getActionScriptElement(environment) }
 
     private val commands = mutableListOf<ScriptGenerationAction<E>>()
 }
@@ -164,7 +164,7 @@ class ThenBuilder<out CF : CheckFactory, E : ScriptGenerationEnvironment>(
     override fun fromScenario(scenario: VerifiableScenario<*, in CF>) = fromChecks(scenario.checks(checkFactory))
 
     override val builtScriptElements
-        get() = (if (compose) composedChecks else checks).map { ScriptStringFragment(it.getCheckScript(environment)) }
+        get() = (if (compose) composedChecks else checks).map { it.getCheckScriptElement(environment) }
 
     private val composedChecks
         get() = checks.map {
@@ -215,7 +215,7 @@ class QueryBuilder<out QF : QueryFactory, E : ScriptGenerationEnvironment>(
         fromScenarioQueries(scenario.queries(queryFactory))
 
     override val builtScriptElements
-        get() = queries.map { ScriptStringFragment(it.getQueryScript()) } + derivedQueries.map { ScriptStringFragment(it.getDerivedQueryScript()) }
+        get() = queries.map { it.getQueryScriptElement() } + derivedQueries.map { it.getDerivedQueryScriptElement() }
 
     private val queries = mutableListOf<ScriptGenerationQuery<*>>()
     private val derivedQueries = mutableListOf<ScriptGenerationDerivedQuery<*>>()
@@ -251,7 +251,7 @@ abstract class GenerateBlocksBuilder<out AF : ActionFactory, out QF : QueryFacto
  * Builds an individual block in a list of generate blocks.
  */
 @ScriptGenerationDsl
-class GenerateBlockBuilder() : BasicScriptBlockBuilder() {
+class GenerateBlockBuilder : BasicScriptBlockBuilder() {
 
     fun build(body: GenerateBlockBuilder.() -> Unit) = apply(body).scriptElements
 
@@ -264,7 +264,7 @@ class GenerateBlockBuilder() : BasicScriptBlockBuilder() {
     }
 
     private val actionGenerators = mutableListOf<ScriptGenerationActionGenerator>()
-    override val builtScriptElements get() = actionGenerators.map { ScriptStringFragment(it.getActionGeneratorScript()) }
+    override val builtScriptElements get() = actionGenerators.map { it.getActionGeneratorScriptElement() }
 }
 
 @ScriptGenerationDsl

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationCheck.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationCheck.kt
@@ -11,6 +11,17 @@ interface ScriptGenerationCheck<E : ScriptGenerationEnvironment> : Check {
      */
     @Throws(IllegalStateException::class)
     fun getCheckScript(environment: E): String
+
+
+    /**
+     * As `getCheckScript`, but returns a renderable script element instead of a string.
+     *
+     * By default, this returns an element that wraps the contents of `getCheckScript`.
+     * Override this for more control over the script generation of a check.
+     * (If doing so, consider making `getCheckScript` call the `render` method of the script element for consistency.)
+     */
+    @Throws(IllegalStateException::class)
+    fun getCheckScriptElement(environment: E): ScriptElement = ScriptStringFragment(getCheckScript(environment))
 }
 
 interface ComposableScriptGenerationCheck<E : ScriptGenerationEnvironment> : ScriptGenerationCheck<E> {
@@ -44,5 +55,6 @@ inline fun <E : ScriptGenerationEnvironment> onlyComposable(crossinline register
 
         override val behavior = unsupportedBehavior
         override fun getCheckScript(environment: E) = error("This check cannot be scriptified directly and must be composed")
+        override fun getCheckScriptElement(environment: E) = error("This check cannot be scriptified directly and must be composed")
         override fun registerComposable(environment: E) = environment.register()
     }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationCheck.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationCheck.kt
@@ -12,7 +12,6 @@ interface ScriptGenerationCheck<E : ScriptGenerationEnvironment> : Check {
     @Throws(IllegalStateException::class)
     fun getCheckScript(environment: E): String
 
-
     /**
      * As `getCheckScript`, but returns a renderable script element instead of a string.
      *

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationDerivedQuery.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationDerivedQuery.kt
@@ -5,4 +5,14 @@ import com.anaplan.engineering.azuki.core.system.DerivedQuery
 fun interface ScriptGenerationDerivedQuery<T> : DerivedQuery<T> {
 
     fun getDerivedQueryScript(): String
+
+    /**
+     * As `getDerivedQueryScript`, but returns a renderable script element instead of a string.
+     *
+     * By default, this returns an element that wraps the contents of `getDerivedQueryScript`.
+     * Override this for more control over the script generation of a derived query.
+     * (If doing so, consider making `getDerivedQueryScript` call the `render` method of the script element for
+     * consistency.)
+     */
+    fun getDerivedQueryScriptElement(): ScriptElement = ScriptStringFragment(getDerivedQueryScript())
 }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationQuery.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationQuery.kt
@@ -5,6 +5,15 @@ import com.anaplan.engineering.azuki.core.system.Query
 interface ScriptGenerationQuery<T> : Query<T> {
 
     fun getQueryScript(): String
+
+    /**
+     * As `getQueryScript`, but returns a renderable script element instead of a string.
+     *
+     * By default, this returns an element that wraps the contents of `getQueryScript`.
+     * Override this for more control over the script generation of a query.
+     * (If doing so, consider making `getQueryScript` call the `render` method of the script element for consistency.)
+     */
+    fun getQueryScriptElement(): ScriptElement = ScriptStringFragment(getQueryScript())
 }
 
 /**

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptingHelper.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptingHelper.kt
@@ -6,7 +6,7 @@ import kotlin.reflect.KType
 
 class ScriptingHelper(private val valueScripters: Map<KClassifier, (Any?) -> String>) {
 
-    fun scriptifyFunction(fn: KFunction<*>, vararg values: Any?): String {
+    fun scriptifyFunctionAsElement(fn: KFunction<*>, vararg values: Any?): ScriptFunction {
         if (fn.parameters.filter { !it.isOptional }.size > values.size + 1) {
             throw IllegalStateException("Too few parameters for ${fn.name}: ${values.toList()}")
         }
@@ -19,10 +19,15 @@ class ScriptingHelper(private val valueScripters: Map<KClassifier, (Any?) -> Str
             } else {
                 null
             }
+            // TODO: scriptify parameter as element
             scriptifyParameter(p.type, v, p.isVararg, requiredName)
         }
-        return "${fn.name}(${paramStrings.filterNotNull().joinToString(", ")})"
+
+        return ScriptFunction(fn.name, paramStrings.filterNotNull().map(::ScriptStringFragment))
     }
+
+    fun scriptifyFunction(fn: KFunction<*>, vararg values: Any?) = scriptifyFunctionAsElement(fn, *values).render(
+        RenderContext())
 
     fun scriptifyParameter(
         expectedType: KType,

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceFunctionsTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceFunctionsTest.kt
@@ -1,0 +1,212 @@
+package com.anaplan.engineering.azuki.script.generation
+
+import kotlin.test.*
+
+class ScriptGenerationServiceFunctionsTest {
+    @Test
+    fun renderScriptFunctionsExampleScenario() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(a)
+                    thereIsABar(a, b)
+                    thereIsABaz(
+                        a, a,
+            ${"\"\"\""}
+            a b c
+            d e f
+            g h i
+            ${"\"\"\""},
+                        b,
+            ${"\"\"\""}
+            a b c
+            d e f
+            g h i
+            ${"\"\"\""},
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", argA)
+                +scriptFunction("thereIsABar", argA, argB)
+                +scriptFunction("thereIsABaz", argA, argA, longArg, argB, longArg)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsWithHorizontalVerticalHorizontalArguments() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(
+                        a, b,
+            ${"\"\"\""}
+            a b c
+            d e f
+            g h i
+            ${"\"\"\""},
+                        b, a,
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", argA, argB, longArg, argB, argA)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsWithVerticalThenHorizontalArguments() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+                        a, b,
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", longArg, argA, argB)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsWithHorizontalThenVerticalArguments() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(
+                        a, b,
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", argA, argB, longArg)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsWithAllHorizontalArguments() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(a, b, b, a)
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", argA, argB, argB, argA)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsWithAllVerticalArguments() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", longArg, longArg)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    companion object {
+
+        val argA = ScriptStringFragment("a")
+        val argB = ScriptStringFragment("b")
+        val longArg = ScriptStringFragment("${TRIPLE}\na b c\nd e f\ng h i\n${TRIPLE}")
+        const val TRIPLE = "\"\"\""
+
+        val everythingIsOkay = scriptFunction("everythingIsOkay")
+
+        fun scriptFunction(name: String, vararg args: ScriptStringFragment) = ScriptFunction(name, listOf(*args))
+
+        fun generateAndRender(
+            body: ScriptGenerationService<*, *, *, *, *, *, *>.() -> ScenarioScript
+        ) = ScriptGenerationService.standalone.body().render {
+            // for these tests we want to see if the standard formatting is good enough
+            formatter = Formatter.None
+        }.trim()
+    }
+}

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceFunctionsTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceFunctionsTest.kt
@@ -3,6 +3,7 @@ package com.anaplan.engineering.azuki.script.generation
 import kotlin.test.*
 
 class ScriptGenerationServiceFunctionsTest {
+
     @Test
     fun renderScriptFunctionsAllHorizontal() {
         val expected = """
@@ -35,11 +36,11 @@ class ScriptGenerationServiceFunctionsTest {
                 given {
                     thereIsAFoo(
                         a, b,
-            ${"\"\"\""}
+            $TRIPLE
             a b c
             d e f
             g h i
-            ${"\"\"\""},
+            $TRIPLE,
                         b, a,
                     )
                 }
@@ -52,6 +53,41 @@ class ScriptGenerationServiceFunctionsTest {
         assertEquals(expected, generateAndRender {
             given {
                 +scriptFunction("thereIsAFoo", argA, argB, longArg, argB, argA)
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsVerticalHorizontalVertical() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+                        a, b, a,
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", longArg, argA, argB, argA, longArg)
             }.whenever {
             }.then {
                 +everythingIsOkay

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceFunctionsTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/ScriptGenerationServiceFunctionsTest.kt
@@ -4,26 +4,12 @@ import kotlin.test.*
 
 class ScriptGenerationServiceFunctionsTest {
     @Test
-    fun renderScriptFunctionsExampleScenario() {
+    fun renderScriptFunctionsAllHorizontal() {
         val expected = """
             verifiableScenario {
                 given {
                     thereIsAFoo(a)
                     thereIsABar(a, b)
-                    thereIsABaz(
-                        a, a,
-            ${"\"\"\""}
-            a b c
-            d e f
-            g h i
-            ${"\"\"\""},
-                        b,
-            ${"\"\"\""}
-            a b c
-            d e f
-            g h i
-            ${"\"\"\""},
-                    )
                 }
                 then {
                     everythingIsOkay()
@@ -35,7 +21,6 @@ class ScriptGenerationServiceFunctionsTest {
             given {
                 +scriptFunction("thereIsAFoo", argA)
                 +scriptFunction("thereIsABar", argA, argB)
-                +scriptFunction("thereIsABaz", argA, argA, longArg, argB, longArg)
             }.whenever {
             }.then {
                 +everythingIsOkay
@@ -44,7 +29,7 @@ class ScriptGenerationServiceFunctionsTest {
     }
 
     @Test
-    fun renderScriptFunctionsWithHorizontalVerticalHorizontalArguments() {
+    fun renderScriptFunctionsHorizontalVerticalHorizontal() {
         val expected = """
             verifiableScenario {
                 given {
@@ -75,90 +60,7 @@ class ScriptGenerationServiceFunctionsTest {
     }
 
     @Test
-    fun renderScriptFunctionsWithVerticalThenHorizontalArguments() {
-        val expected = """
-            verifiableScenario {
-                given {
-                    thereIsAFoo(
-            $TRIPLE
-            a b c
-            d e f
-            g h i
-            $TRIPLE,
-                        a, b,
-                    )
-                }
-                then {
-                    everythingIsOkay()
-                }
-            }
-        """.trimIndent()
-
-        assertEquals(expected, generateAndRender {
-            given {
-                +scriptFunction("thereIsAFoo", longArg, argA, argB)
-            }.whenever {
-            }.then {
-                +everythingIsOkay
-            }.verifiableScenario
-        })
-    }
-
-    @Test
-    fun renderScriptFunctionsWithHorizontalThenVerticalArguments() {
-        val expected = """
-            verifiableScenario {
-                given {
-                    thereIsAFoo(
-                        a, b,
-            $TRIPLE
-            a b c
-            d e f
-            g h i
-            $TRIPLE,
-                    )
-                }
-                then {
-                    everythingIsOkay()
-                }
-            }
-        """.trimIndent()
-
-        assertEquals(expected, generateAndRender {
-            given {
-                +scriptFunction("thereIsAFoo", argA, argB, longArg)
-            }.whenever {
-            }.then {
-                +everythingIsOkay
-            }.verifiableScenario
-        })
-    }
-
-    @Test
-    fun renderScriptFunctionsWithAllHorizontalArguments() {
-        val expected = """
-            verifiableScenario {
-                given {
-                    thereIsAFoo(a, b, b, a)
-                }
-                then {
-                    everythingIsOkay()
-                }
-            }
-        """.trimIndent()
-
-        assertEquals(expected, generateAndRender {
-            given {
-                +scriptFunction("thereIsAFoo", argA, argB, argB, argA)
-            }.whenever {
-            }.then {
-                +everythingIsOkay
-            }.verifiableScenario
-        })
-    }
-
-    @Test
-    fun renderScriptFunctionsWithAllVerticalArguments() {
+    fun renderScriptFunctionsAllVertical() {
         val expected = """
             verifiableScenario {
                 given {
@@ -191,6 +93,60 @@ class ScriptGenerationServiceFunctionsTest {
         })
     }
 
+    @Test
+    fun renderScriptFunctionsNestedHorizontal() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(bar(a, b))
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", scriptFunction("bar", argA, argB))
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
+    @Test
+    fun renderScriptFunctionsNestedVertical() {
+        val expected = """
+            verifiableScenario {
+                given {
+                    thereIsAFoo(
+                        bar(
+            $TRIPLE
+            a b c
+            d e f
+            g h i
+            $TRIPLE,
+                        ),
+                    )
+                }
+                then {
+                    everythingIsOkay()
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expected, generateAndRender {
+            given {
+                +scriptFunction("thereIsAFoo", scriptFunction("bar", longArg))
+            }.whenever {
+            }.then {
+                +everythingIsOkay
+            }.verifiableScenario
+        })
+    }
+
     companion object {
 
         val argA = ScriptStringFragment("a")
@@ -200,7 +156,7 @@ class ScriptGenerationServiceFunctionsTest {
 
         val everythingIsOkay = scriptFunction("everythingIsOkay")
 
-        fun scriptFunction(name: String, vararg args: ScriptStringFragment) = ScriptFunction(name, listOf(*args))
+        fun scriptFunction(name: String, vararg args: ScriptElement) = ScriptFunction(name, listOf(*args))
 
         fun generateAndRender(
             body: ScriptGenerationService<*, *, *, *, *, *, *>.() -> ScenarioScript

--- a/graphs/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/GraphScriptGenerationActionFactory.kt
+++ b/graphs/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/graphs/adapter/scriptgen/GraphScriptGenerationActionFactory.kt
@@ -25,67 +25,78 @@ object GraphScriptGenerationActionFactory : GraphActionFactory<GraphScriptGenera
 
 typealias GraphScriptGenerationAction = ScriptGenerationAction<NoScriptGenerationEnvironment>
 
+interface GraphScriptElementGenerationAction : GraphScriptGenerationAction {
+
+    override fun getActionScript(environment: NoScriptGenerationEnvironment) =
+        getActionScriptElement(environment).render(RenderContext())
+
+    abstract override fun getActionScriptElement(environment: NoScriptGenerationEnvironment): ScriptElement
+}
+
 private object UndirectedGraphScriptGenActionFactory : UndirectedGraphActionFactory {
 
     private class AddEdgeToUndirectedGraphScriptGenerationAction<V>(graphName: String, source: V, target: V) :
-        AddEdgeToUndirectedGraphDeclarableAction<V>(graphName, source, target), GraphScriptGenerationAction {
+        AddEdgeToUndirectedGraphDeclarableAction<V>(graphName, source, target), GraphScriptElementGenerationAction {
 
-        override fun getActionScript(environment: NoScriptGenerationEnvironment) =
-            GraphScriptingHelper.scriptifyFunction(UndirectedGraphActions::addEdgeToUndirectedGraph,
+        override fun getActionScriptElement(environment: NoScriptGenerationEnvironment) =
+            GraphScriptingHelper.scriptifyFunctionAsElement(UndirectedGraphActions::addEdgeToUndirectedGraph,
                 graphName,
                 source,
                 target)
     }
 
     private class AddVertexToUndirectedGraphScriptGenerationAction<V>(graphName: String, vertex: V) :
-        AddVertexToUndirectedGraphDeclarableAction<V>(graphName, vertex), GraphScriptGenerationAction {
+        AddVertexToUndirectedGraphDeclarableAction<V>(graphName, vertex), GraphScriptElementGenerationAction {
 
-        override fun getActionScript(environment: NoScriptGenerationEnvironment) =
-            GraphScriptingHelper.scriptifyFunction(UndirectedGraphActions::addVertexToUndirectedGraph,
+        override fun getActionScriptElement(environment: NoScriptGenerationEnvironment) =
+            GraphScriptingHelper.scriptifyFunctionAsElement(UndirectedGraphActions::addVertexToUndirectedGraph,
                 graphName,
                 vertex)
     }
 
     private class CreateUndirectedGraphScriptGenerationAction(graphName: String) :
-        CreateUndirectedGraphDeclarableAction(graphName), GraphScriptGenerationAction {
+        CreateUndirectedGraphDeclarableAction(graphName), GraphScriptElementGenerationAction {
 
-        override fun getActionScript(environment: NoScriptGenerationEnvironment) =
-            GraphScriptingHelper.scriptifyFunction(UndirectedGraphActions::createUndirected, graphName)
+        override fun getActionScriptElement(environment: NoScriptGenerationEnvironment) =
+            GraphScriptingHelper.scriptifyFunctionAsElement(UndirectedGraphActions::createUndirected, graphName)
     }
 
-    override fun create(graphName: String): GraphScriptGenerationAction = CreateUndirectedGraphScriptGenerationAction(graphName)
+    override fun create(graphName: String): GraphScriptGenerationAction =
+        CreateUndirectedGraphScriptGenerationAction(graphName)
 
-    override fun <V> addEdge(graphName: String, source: V, target: V): GraphScriptGenerationAction =
+    override fun <V> addEdge(graphName: String, source: V, target: V): GraphScriptElementGenerationAction =
         AddEdgeToUndirectedGraphScriptGenerationAction(graphName, source, target)
 
-    override fun <V> addVertex(graphName: String, vertex: V): GraphScriptGenerationAction =
+    override fun <V> addVertex(graphName: String, vertex: V): GraphScriptElementGenerationAction =
         AddVertexToUndirectedGraphScriptGenerationAction(graphName, vertex)
 }
 
 private object DirectedGraphScriptGenActionFactory : DirectedGraphActionFactory {
 
     private class CreateDirectedGraphScriptGenerationAction(graphName: String) :
+        CreateUndirectedGraphDeclarableAction(graphName), GraphScriptElementGenerationAction {
 
-        CreateUndirectedGraphDeclarableAction(graphName), GraphScriptGenerationAction {
-        override fun getActionScript(environment: NoScriptGenerationEnvironment) =
-            GraphScriptingHelper.scriptifyFunction(DirectedGraphActions::createDirected, graphName)
+        override fun getActionScriptElement(environment: NoScriptGenerationEnvironment) =
+            GraphScriptingHelper.scriptifyFunctionAsElement(DirectedGraphActions::createDirected, graphName)
     }
 
     private class AddEdgeToDirectedGraphScriptGenerationAction<V>(graphName: String, source: V, target: V) :
-        AddEdgeToDirectedGraphDeclarableAction<V>(graphName, source, target), GraphScriptGenerationAction {
+        AddEdgeToDirectedGraphDeclarableAction<V>(graphName, source, target), GraphScriptElementGenerationAction {
 
-        override fun getActionScript(environment: NoScriptGenerationEnvironment) =
-            GraphScriptingHelper.scriptifyFunction(DirectedGraphActions::addEdgeToDirectedGraph,
+        override fun getActionScriptElement(environment: NoScriptGenerationEnvironment) =
+            GraphScriptingHelper.scriptifyFunctionAsElement(DirectedGraphActions::addEdgeToDirectedGraph,
                 graphName,
                 source,
                 target)
     }
 
     private class AddVertexToDirectedGraphScriptGenerationAction<V>(graphName: String, vertex: V) :
-        AddVertexToDirectedGraphDeclarableAction<V>(graphName, vertex), GraphScriptGenerationAction {
+        AddVertexToDirectedGraphDeclarableAction<V>(graphName, vertex), GraphScriptElementGenerationAction {
 
-        override fun getActionScript(environment: NoScriptGenerationEnvironment) =
-            GraphScriptingHelper.scriptifyFunction(DirectedGraphActions::addVertexToDirectedGraph, graphName, vertex)
+        override fun getActionScriptElement(environment: NoScriptGenerationEnvironment) =
+            GraphScriptingHelper.scriptifyFunctionAsElement(DirectedGraphActions::addVertexToDirectedGraph,
+                graphName,
+                vertex)
     }
 
     override fun create(graphName: String): GraphScriptGenerationAction =

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationQueryFactory.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationQueryFactory.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KFunction
  * Root class for the three types of query factory (queries in query position, queries in verification position,
  * and queries in derived position).
  */
-abstract class AbstractTicTacToeScriptGenerationQueryFactory() : TicTacToeQueryFactory {
+abstract class AbstractTicTacToeScriptGenerationQueryFactory : TicTacToeQueryFactory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T, C : Collection<T>> createForAllQuery(

--- a/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
+++ b/tictactoe/adapter-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGeneratorTest.kt
@@ -117,11 +117,14 @@ class TicTacToeScriptGeneratorTest {
         }
 
         expect("""
-            boardHasState(${TRIPLE}gameA${TRIPLE}, $TRIPLE
+            boardHasState(
+                ${TRIPLE}gameA${TRIPLE},
+            $TRIPLE
             X | O | X
             . | . | .
             O | . | X
-            $TRIPLE)
+            $TRIPLE,
+            )
         """.trimIndent()) { renderedThenElements(scenario).singleOrNull() }
     }
 


### PR DESCRIPTION
This PR changes the script generation interfaces (`ScriptGenerationAction` et al.) to have an optional variant of their main scriptification function returning `ScriptElement`s instead of `String`s.

By default, the new functions delegate to the existing ones and wrap the results in `StringScriptFragment`, which directly corresponds to the old behaviour (just shifted left into the individual actions, checks, etc.).  However, it is now possible to invert this, make the new functions return `ScriptElement`s, and have the old versions `render` them.  This isn't _very_ useful right now, but opens us up to being able to make action, check, etc. scripting able to:

- indent properly
- notify any outer constructs how to render themselves around inner constructs
- anything else we could theoretically push through a `RenderContext` or pull through a `ScriptElement`

A large bulk of the PR is spent on a motivating example: replacing the Azuki stock function scriptifier with one that uses `ScriptElement`s.  This is both tested to ensure it scriptifies properly with horizontally, vertically, and/or nested arguments, and also applied to some of the examples.  (I didn't exhaustively change the examples because I thought it had diminishing returns.)

_Disclaimer: some parts of this PR (refactoring attempts and test writing) were assisted by Copilot/GPT5.3.  I don't think much direct code contribution from LLM sources survives, but there is definitely some influence._