### PR TITLE
Implement and demonstrate CheckComposerRegistry

### DIFF
--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -35,9 +35,9 @@ fun interface CheckComposer<E : ScriptGenerationEnvironment> {
 interface CheckComposerRegistry<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>> {
 
     /**
-     * Registers a check for composition inside this map, under the given key and with the given effect.
+     * Registers a check for composition inside this registry, under the given key and with the given effect.
      *
-     * If an existing composer exists under the same key, the effect is applied cumulatively to it.
+     * If a composer already exists under the same key, the effect is applied cumulatively to it.
      */
     fun register(key: K, effect: S.() -> S): CheckComposer<E> = tryRegister(key) {
         Result.success(effect())
@@ -90,34 +90,49 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
 }
 
 /**
+ * A check composer registry with only one valid composer (and therefore a single unit key).
+ */
+interface SingleKeyCheckComposerRegistry<E : ScriptGenerationEnvironment, S : CheckComposer<E>> :
+    CheckComposerRegistry<E, Unit, S> {
+
+    /**
+     * Registers a check for composition inside this registry, with the given effect.
+     *
+     * If a composer already exists, the effect is applied cumulatively to it.
+     */
+    fun register(effect: S.() -> S): CheckComposer<E> = tryRegister { Result.success(effect()) }
+
+    /**
+     * As with <code>register()</code>, but can fail, permanently halting composition.
+     */
+    fun tryRegister(effect: S.() -> Result<S>): CheckComposer<E>
+
+    /**
+     * The single composer held by the registry, if active.
+     */
+    val composer: S?
+
+    override fun get(key: Unit): S? = composer
+    override fun register(key: Unit, effect: S.() -> S) = register(effect)
+    override fun tryRegister(key: Unit, effect: S.() -> Result<S>) = tryRegister(effect)
+    override val composers get() = listOfNotNull(composer)
+}
+
+/**
  * Wraps a composer to ensure that effects that replace it with another object propagate correctly to the generator.
  *
  * This behaves as a composer registry, but with one fixed key and whose registration functions return the wrapper as
  * a composer in its own right.
  */
 class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E>,
-    CheckComposerRegistry<E, Unit, S> {
+    SingleKeyCheckComposerRegistry<E, S> {
 
     private var _inner = Result.success(initial)
 
-    override fun register(key: Unit, effect: S.() -> S) = register(effect)
-    override fun tryRegister(key: Unit, effect: S.() -> Result<S>) = tryRegister(effect)
-    override operator fun get(key: Unit): S? = composer
-    override val composers get() = listOfNotNull(_inner.getOrNull())
+    override val composer: S? get() = _inner.getOrNull()
+    override fun register(effect: S.() -> S) = apply { _inner = _inner.map(effect) }
+    override fun tryRegister(effect: S.() -> Result<S>) = apply { _inner = bind(effect) }
     override fun compose(environment: E): Result<List<ScriptGenerationCheck<E>>> = bind { compose(environment) }
-
-    val composer: S? get() = _inner.getOrNull()
-
-    /**
-     * Registers a check on the inner composer by applying an effect to it.
-     * If the effect returns a new object, this wrapper updates to point to it.
-     */
-    fun register(effect: S.() -> S) = apply { _inner = _inner.map(effect) }
-
-    /**
-     * As with register(), but can fail, permanently halting composition.
-     */
-    fun tryRegister(effect: S.() -> Result<S>) = apply { _inner = bind(effect) }
 
     private fun <T> bind(fn: S.() -> Result<T>) = _inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
 }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -85,7 +85,7 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
         getOrInit(key).tryRegister(Unit, effect)
 
     override operator fun get(key: K): S? = map[key]?.get(Unit)
-    override val composers get() = map.values.flatMap { it.composers }
+    override val composers get() = map.values.mapNotNull { it[Unit] }
 
     private fun getOrInit(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
 }

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -25,15 +25,18 @@ fun interface CheckComposer<E : ScriptGenerationEnvironment> {
 /**
  * Handles registering check composers against keys, allowing discovery and composition of related checks.
  *
- * A typical pattern of usage here is for every check that constrains a particular domain object to register itself
- * in the registrar for that type of domain object, under a key that uniquely identifies that particular object.  Each
- * registration will add that check's information to a composer for that key, ensuring that each domain object has
- *
+ * A typical use case is for composable checks that constrain a particular domain object to <code>register</code>
+ * themselves in a registry corresponding to a group of checks that can be composed into each other.  Each object is
+ * registered under a key that uniquely identifies that object.  Each registration then adds that check's information to
+ * a composer for that key, ensuring that each domain object has one and only one distinct composer.  Said composer is
+ * then returned by <code>register</code>, and eventually used to look up the checks that resulted from the composition
+ * effort.
  */
 interface CheckComposerRegistry<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>> {
 
     /**
      * Registers a check for composition inside this map, under the given key and with the given effect.
+     *
      * If an existing composer exists under the same key, the effect is applied cumulatively to it.
      */
     fun register(key: K, effect: S.() -> S): CheckComposer<E> = tryRegister(key) {
@@ -41,27 +44,40 @@ interface CheckComposerRegistry<E : ScriptGenerationEnvironment, K, S : CheckCom
     }
 
     /**
-     * As with register(), but can fail, permanently halting composition for this key.
+     * As with <code>register()</code>, but can fail, permanently halting composition for this key.
      */
     fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E>
 
     /**
-     * Gets the composer for a given key, if one exists.
+     * Gets the current composer for a given key, if one exists.
+     *
+     * It is not safe to use the output of this function after calling <code>register</code> or <code>tryRegister</code>
+     * on this key, as they may cause the composer under that key to change its object identity.
      */
     operator fun get(key: K): S?
 
     /**
-     * Gets all composers registered in this registry.
+     * Gets all currently-active composers registered in this registry.
+     *
+     * It is not safe to use the value of this property after calling <code>register</code> or <code>tryRegister</code>,
+     * as they may cause composers to fail or
      */
     val composers: Collection<S>
 }
 
 /**
  * Implements a check composer registry with a keyed map.
+ *
+ * This is usable directly or through delegation from another <code>CheckComposerRegistry</code>.
  */
 class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>(val constructor: (K) -> S) :
     CheckComposerRegistry<E, K, S> {
 
+    /* We use CheckComposerWrapper here because, when register/tryRegister are applied to an existing key, they can
+     * replace the underlying S object inside the map.  This would ordinarily leave the CheckComposer<E> that was
+     * returned to previous calls dangling and pointing to the old S object.  Instead, we always store the same wrapper,
+     * return that wrapper as the CheckComposer<E>, and cascade all registration attempts into the wrapper.
+     */
     private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
 
     override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -80,12 +80,11 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
      */
     private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
 
-    override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(Unit, effect)
-    override fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> =
-        getOrInit(key).tryRegister(Unit, effect)
+    override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)
+    override fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = getOrInit(key).tryRegister(effect)
 
-    override operator fun get(key: K): S? = map[key]?.get(Unit)
-    override val composers get() = map.values.mapNotNull { it[Unit] }
+    override operator fun get(key: K): S? = map[key]?.composer
+    override val composers get() = map.values.mapNotNull { it.composer }
 
     private fun getOrInit(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
 }
@@ -99,16 +98,28 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
 class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E>,
     CheckComposerRegistry<E, Unit, S> {
 
-    private var inner = Result.success(initial)
+    private var _inner = Result.success(initial)
 
-    override fun register(key: Unit, effect: S.() -> S) = apply { inner = inner.map(effect) }
-    override fun tryRegister(key: Unit, effect: S.() -> Result<S>) = apply { inner = bind(effect) }
-    override operator fun get(key: Unit): S? = inner.getOrNull()
-    override val composers get() = listOfNotNull(inner.getOrNull())
-
+    override fun register(key: Unit, effect: S.() -> S) = register(effect)
+    override fun tryRegister(key: Unit, effect: S.() -> Result<S>) = tryRegister(effect)
+    override operator fun get(key: Unit): S? = composer
+    override val composers get() = listOfNotNull(_inner.getOrNull())
     override fun compose(environment: E): Result<List<ScriptGenerationCheck<E>>> = bind { compose(environment) }
 
-    private fun <T> bind(fn: S.() -> Result<T>) = inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
+    val composer: S? get() = _inner.getOrNull()
+
+    /**
+     * Registers a check on the inner composer by applying an effect to it.
+     * If the effect returns a new object, this wrapper updates to point to it.
+     */
+    fun register(effect: S.() -> S) = apply { _inner = _inner.map(effect) }
+
+    /**
+     * As with register(), but can fail, permanently halting composition.
+     */
+    fun tryRegister(effect: S.() -> Result<S>) = apply { _inner = bind(effect) }
+
+    private fun <T> bind(fn: S.() -> Result<T>) = _inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
 }
 
 internal fun <E : ScriptGenerationEnvironment> composeChecks(

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -23,31 +23,53 @@ fun interface CheckComposer<E : ScriptGenerationEnvironment> {
 }
 
 /**
- * Holds a keyed map of check composers.
+ * Handles registering check composers against keys, allowing discovery and composition of related checks.
+ *
+ * A typical pattern of usage here is for every check that constrains a particular domain object to register itself
+ * in the registrar for that type of domain object, under a key that uniquely identifies that particular object.  Each
+ * registration will add that check's information to a composer for that key, ensuring that each domain object has
+ *
  */
-class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>(val constructor: (K) -> S) {
-
-    private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
+interface CheckComposerRegistry<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>> {
 
     /**
      * Registers a check for composition inside this map, under the given key and with the given effect.
      * If an existing composer exists under the same key, the effect is applied cumulatively to it.
      */
-    fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)
+    fun register(key: K, effect: S.() -> S): CheckComposer<E> = tryRegister(key) {
+        Result.success(effect())
+    }
 
     /**
-     * As with register(), but can fail, permanently halting composition for this key
+     * As with register(), but can fail, permanently halting composition for this key.
      */
-    fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = getOrInit(key).tryRegister(effect)
+    fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E>
+
+    /**
+     * Gets the composer for a given key, if one exists.
+     */
+    operator fun get(key: K): S?
+
+    /**
+     * Gets all composers registered in this registry.
+     */
+    val composers: Collection<S>
+}
+
+/**
+ * Implements a check composer registry with a keyed map.
+ */
+class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>(val constructor: (K) -> S) :
+    CheckComposerRegistry<E, K, S> {
+
+    private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
+
+    override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)
+    override fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = getOrInit(key).tryRegister(effect)
+    override operator fun get(key: K): S? = map[key]?.composer
+    override val composers get() = map.values.mapNotNull { it.composer }
 
     private fun getOrInit(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
-
-    /**
-     * Gets the composer for a key, provided that it hasn't been removed through failure.
-     */
-    operator fun get(key: K): S? = map[key]?.composer
-
-    val composers get() = map.values.mapNotNull { it.composer }
 }
 
 /**

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -80,36 +80,35 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
      */
     private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
 
-    override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)
-    override fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = getOrInit(key).tryRegister(effect)
-    override operator fun get(key: K): S? = map[key]?.composer
-    override val composers get() = map.values.mapNotNull { it.composer }
+    override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(Unit, effect)
+    override fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> =
+        getOrInit(key).tryRegister(Unit, effect)
+
+    override operator fun get(key: K): S? = map[key]?.get(Unit)
+    override val composers get() = map.values.flatMap { it.composers }
 
     private fun getOrInit(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
 }
 
 /**
  * Wraps a composer to ensure that effects that replace it with another object propagate correctly to the generator.
+ *
+ * This behaves as a composer registry, but with one fixed key and whose registration functions return the wrapper as
+ * a composer in its own right.
  */
-class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E> {
+class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E>,
+    CheckComposerRegistry<E, Unit, S> {
 
-    private var _inner = Result.success(initial)
-    val composer: S? get() = _inner.getOrNull()
+    private var inner = Result.success(initial)
 
-    /**
-     * Registers a check on the inner composer by applying an effect to it.
-     * If the effect returns a new object, this wrapper updates to point to it.
-     */
-    fun register(effect: S.() -> S) = apply { _inner = _inner.map(effect) }
-
-    /**
-     * As with register(), but can fail, permanently halting composition.
-     */
-    fun tryRegister(effect: S.() -> Result<S>) = apply { _inner = bind(effect) }
+    override fun register(key: Unit, effect: S.() -> S) = apply { inner = inner.map(effect) }
+    override fun tryRegister(key: Unit, effect: S.() -> Result<S>) = apply { inner = bind(effect) }
+    override operator fun get(key: Unit): S? = inner.getOrNull()
+    override val composers get() = listOfNotNull(inner.getOrNull())
 
     override fun compose(environment: E): Result<List<ScriptGenerationCheck<E>>> = bind { compose(environment) }
 
-    private fun <T> bind(fn: S.() -> Result<T>) = _inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
+    private fun <T> bind(fn: S.() -> Result<T>) = inner.fold(onSuccess = fn, onFailure = { Result.failure(it) })
 }
 
 internal fun <E : ScriptGenerationEnvironment> composeChecks(

--- a/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
+++ b/azuki-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposer.kt
@@ -35,32 +35,16 @@ fun interface CheckComposer<E : ScriptGenerationEnvironment> {
 interface CheckComposerRegistry<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>> {
 
     /**
-     * Registers a check for composition inside this registry, under the given key and with the given effect.
+     * Gets the composer container for a particular key, creating one if one doesn't yet exist.
      *
-     * If a composer already exists under the same key, the effect is applied cumulatively to it.
+     * This container permits registering a composable check for the domain object corresponding to its key.
      */
-    fun register(key: K, effect: S.() -> S): CheckComposer<E> = tryRegister(key) {
-        Result.success(effect())
-    }
-
-    /**
-     * As with <code>register()</code>, but can fail, permanently halting composition for this key.
-     */
-    fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E>
-
-    /**
-     * Gets the current composer for a given key, if one exists.
-     *
-     * It is not safe to use the output of this function after calling <code>register</code> or <code>tryRegister</code>
-     * on this key, as they may cause the composer under that key to change its object identity.
-     */
-    operator fun get(key: K): S?
+    fun onKey(key: K): CheckComposerContainer<E, S>
 
     /**
      * Gets all currently-active composers registered in this registry.
      *
-     * It is not safe to use the value of this property after calling <code>register</code> or <code>tryRegister</code>,
-     * as they may cause composers to fail or
+     * It is not safe to use the value of this property after modifying a registration through <code>on</code>.
      */
     val composers: Collection<S>
 }
@@ -80,20 +64,48 @@ class CheckComposerMap<E : ScriptGenerationEnvironment, K, S : CheckComposer<E>>
      */
     private val map = mutableMapOf<K, CheckComposerWrapper<E, S>>()
 
-    override fun register(key: K, effect: S.() -> S): CheckComposer<E> = getOrInit(key).register(effect)
-    override fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = getOrInit(key).tryRegister(effect)
+    override fun onKey(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
 
-    override operator fun get(key: K): S? = map[key]?.composer
     override val composers get() = map.values.mapNotNull { it.composer }
 
-    private fun getOrInit(key: K) = map.getOrPut(key) { CheckComposerWrapper(constructor(key)) }
+    /**
+     * Registers a check for composition inside this registry, under the given key and with the given effect.
+     *
+     * If a composer already exists under the same key, the effect is applied cumulatively to it.
+     */
+    @Deprecated("Use onKey(key)", ReplaceWith("onKey(key).register(effect)"))
+    fun register(key: K, effect: S.() -> S): CheckComposer<E> = onKey(key).register(effect)
+
+    /**
+     * As with <code>register()</code>, but can fail, permanently halting composition for this key.
+     */
+    @Deprecated("Use onKey(key)", ReplaceWith("onKey(key).tryRegister(effect)"))
+    fun tryRegister(key: K, effect: S.() -> Result<S>): CheckComposer<E> = onKey(key).tryRegister(effect)
+
+    /**
+     * Gets the current composer for a given key, if one exists.
+     *
+     * The difference between this and <code>onKey(key).composer</code> is that this function returns null if
+     * <code>on</code> has never been called for <code>key</code>.
+     *
+     * It is not safe to use the output of this function after modifying a registration for this key through
+     * <code>on</code>.  Doing so may cause the composer under that key to change its object identity.
+     */
+    @Deprecated("Use onKey(key) but note difference in behavior")
+    operator fun get(key: K): S? = map[key]?.composer
 }
 
 /**
- * A check composer registry with only one valid composer (and therefore a single unit key).
+ * A container for a single registration of one composer.
+ *
+ * Such a container can be viewed as a registry with only one valid composer (and therefore a single unit key).
+ * It can also be used as a composer (by composing it into its inner composer).
  */
-interface SingleKeyCheckComposerRegistry<E : ScriptGenerationEnvironment, S : CheckComposer<E>> :
-    CheckComposerRegistry<E, Unit, S> {
+interface CheckComposerContainer<E : ScriptGenerationEnvironment, S : CheckComposer<E>> :
+    CheckComposerRegistry<E, Unit, S>, CheckComposer<E> {
+
+    override fun onKey(key: Unit) = this
+    override val composers get() = listOfNotNull(composer)
 
     /**
      * Registers a check for composition inside this registry, with the given effect.
@@ -111,11 +123,6 @@ interface SingleKeyCheckComposerRegistry<E : ScriptGenerationEnvironment, S : Ch
      * The single composer held by the registry, if active.
      */
     val composer: S?
-
-    override fun get(key: Unit): S? = composer
-    override fun register(key: Unit, effect: S.() -> S) = register(effect)
-    override fun tryRegister(key: Unit, effect: S.() -> Result<S>) = tryRegister(effect)
-    override val composers get() = listOfNotNull(composer)
 }
 
 /**
@@ -124,8 +131,8 @@ interface SingleKeyCheckComposerRegistry<E : ScriptGenerationEnvironment, S : Ch
  * This behaves as a composer registry, but with one fixed key and whose registration functions return the wrapper as
  * a composer in its own right.
  */
-class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) : CheckComposer<E>,
-    SingleKeyCheckComposerRegistry<E, S> {
+class CheckComposerWrapper<E : ScriptGenerationEnvironment, S : CheckComposer<E>>(initial: S) :
+    CheckComposerContainer<E, S> {
 
     private var _inner = Result.success(initial)
 

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
@@ -7,106 +7,53 @@ class CheckComposerTest {
 
     @Test
     fun mapRegisterReusesSameComposer() {
-        val map = CheckComposerMap(Example::new)
-        map.register("a") { increment() }
-        map.register("b") { increment() }
-        map.register("a") { increment() }
-        map.register("b") { increment() }
-        map.register("a") { increment() }
-
-        expect(2, "should only be two composers") { map.composers.size }
-        expect(3, "increments to a should have been cumulative") { map["a"]?.counter }
-        expect(2, "increments to b should have been cumulative") { map["b"]?.counter }
+        assertRegisterReusesSameComposer(keyIncrements = listOf("a", "b", "a", "b", "a"), makeMap())
     }
 
     @Test
     fun mapRegisterUpdatesMapOnObjectChange() {
-        val map = CheckComposerMap(Example::new)
-        map.register("a") { increment() }
-        assertIs<Forwards>(map["a"])
-        map.register("a") { reverse() }
-        assertIs<Backwards>(map["a"])
+        assertRegisterUpdatesRegistryOnObjectChange("a", makeMap())
     }
 
     @Test
     fun mapTryRegisterRemovesFromMapOnFailure() {
-        val map = CheckComposerMap(Example::new)
-        map.register("a") { increment() }
-        assertIs<Forwards>(map["a"])
-        map.tryRegister("a") { Result.failure(IllegalStateException("oops")) }
-        assertNull(map["a"], "a should now appear to have been removed")
+        assertTryRegisterNullifiesOnFailure("a", makeMap())
     }
 
     @Test
     fun mapPropagatesComposerObjectChanges() {
-        val map = CheckComposerMap(Example::new)
-        val composerA = map.register("a") { increment() }
-        expect("forwards(1)") { composerA.toScript() }
-        val composerB = map.register("a") { reverse() }
-        listOf(composerA, composerB).forEach { c -> expect("backwards(0)") { c.toScript() } }
-        val composerC = map.register("a") { increment() }
-        listOf(composerA, composerB, composerC).forEach { c -> expect("backwards(-1)") { c.toScript() } }
-        val composerD = map.tryRegister("a") { fail() }
-        listOf(composerA, composerB, composerC, composerD).forEach { c ->
-            assertIs<IllegalStateException>(c.compose(NoScriptGenerationEnvironment).exceptionOrNull())
-        }
+        assertRegistryPropagatesComposerObjectChanges("a", makeMap())
     }
 
     @Test
     fun mapPropagatesComposerFailures() {
-        val map = CheckComposerMap(Example::new)
-        val composer = map.register("a") { increment() }
-        assertIs<Forwards>(map["a"])
-        map.tryRegister("a") { Result.failure(IllegalStateException("oops")) }
-        assertIs<IllegalStateException>( composer.compose(NoScriptGenerationEnvironment).exceptionOrNull(),
-            "should have changed the inner object")
+        assertRegistryPropagatesComposerFailures("a", makeMap())
     }
 
     @Test
     fun wrapperRegisterReusesSameComposer() {
-        val wrapper = CheckComposerWrapper(Example.new("a"))
-        expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
-        wrapper.register { increment() }
-        wrapper.register { increment() }
-        wrapper.register { increment() }
-        wrapper.register { increment() }
-        wrapper.register { increment() }
-        expect("forwards(5)", "should have mutated the same object") { wrapper.toScript() }
+        // we can consider a wrapper to be a registry with only one key: Unit
+        assertRegisterReusesSameComposer(keyIncrements = listOf(Unit, Unit, Unit, Unit, Unit), makeWrapper())
     }
 
     @Test
     fun wrapperRegisterUpdatesComposerOnObjectChange() {
-        val wrapper = CheckComposerWrapper(Example.new("a"))
-        wrapper.register { increment() }
-        assertIs<Forwards>(wrapper.composer)
-        wrapper.register { reverse() }
-        assertIs<Backwards>(wrapper.composer)
+        assertRegisterUpdatesRegistryOnObjectChange(Unit, makeWrapper())
     }
 
     @Test
     fun wrapperTryRegisterNullifiesOnFailure() {
-        val wrapper = CheckComposerWrapper(Example.new("a"))
-        wrapper.register { increment() }
-        assertIs<Forwards>(wrapper.composer)
-        wrapper.tryRegister { Result.failure(IllegalStateException("oops")) }
-        assertNull(wrapper.composer, "a should now appear to have been removed")
+        assertTryRegisterNullifiesOnFailure(Unit, makeWrapper())
     }
 
     @Test
     fun wrapperPropagatesComposerObjectChanges() {
-        val wrapper = CheckComposerWrapper(Example.new("a"))
-        expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
-        wrapper.register { reverse() }
-        expect("backwards(0)", "should have changed the inner object") { wrapper.toScript() }
+        assertRegistryPropagatesComposerObjectChanges(Unit, makeWrapper())
     }
 
     @Test
     fun wrapperPropagatesComposerFailures() {
-        val wrapper = CheckComposerWrapper(Example.new("a"))
-        expect("forwards(0)", "should have stored the original object") { wrapper.toScript() }
-        wrapper.tryRegister { Result.failure(IllegalStateException("oops")) }
-        assertIs<IllegalStateException>(wrapper.compose(NoScriptGenerationEnvironment).exceptionOrNull(),
-            "should have changed the inner object")
+        assertRegistryPropagatesComposerFailures(Unit, makeWrapper())
     }
 
     abstract class Example(val name: String) : CheckComposer<NoScriptGenerationEnvironment> {
@@ -148,6 +95,71 @@ class CheckComposerTest {
                 override val behavior = unsupportedBehavior
                 override fun getCheckScript(environment: NoScriptGenerationEnvironment) = "backwards($counter)"
             }))
+    }
+
+    companion object {
+
+        fun makeMap(): CheckComposerMap<NoScriptGenerationEnvironment, String, Example> = CheckComposerMap(Example::new)
+        fun makeWrapper(): CheckComposerWrapper<NoScriptGenerationEnvironment, Example> =
+            CheckComposerWrapper(Example.new("a"))
+
+        // These tests are identical for maps and wrappers, except for registry type and the key(s) in use:
+
+        private fun <K> assertRegisterReusesSameComposer(
+            keyIncrements: List<K>, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
+        ) {
+            keyIncrements.forEach { registry.register(it) { increment() } }
+
+            val keyCounts = keyIncrements.groupBy { it }.mapValues { it.value.size }
+            assertEquals(keyCounts.size, registry.composers.size, "should only be as many composers as keys")
+            keyCounts.forEach { (k, expected) ->
+                assertEquals(expected, registry[k]?.counter, "increments to $k should have been cumulative")
+            }
+        }
+
+        private fun <K> assertRegisterUpdatesRegistryOnObjectChange(
+            key: K, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
+        ) {
+            registry.register(key) { increment() }
+            assertIs<Forwards>(registry[key])
+            registry.register(key) { reverse() }
+            assertIs<Backwards>(registry[key])
+        }
+
+        private fun <K> assertTryRegisterNullifiesOnFailure(
+            key: K, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
+        ) {
+            registry.register(key) { increment() }
+            assertIs<Forwards>(registry[key])
+            registry.tryRegister(key) { Result.failure(IllegalStateException("oops")) }
+            assertNull(registry[key], "the composer should now appear to have been removed")
+        }
+
+        private fun <K> assertRegistryPropagatesComposerObjectChanges(
+            key: K, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
+        ) {
+            val composerA = registry.register(key) { increment() }
+            assertEquals("forwards(1)", composerA.toScript())
+            val composerB = registry.register(key) { reverse() }
+            listOf(composerA, composerB).forEach { c -> assertEquals("backwards(0)", c.toScript()) }
+            val composerC = registry.register(key) { increment() }
+            listOf(composerA, composerB, composerC).forEach { c -> assertEquals("backwards(-1)", c.toScript()) }
+            val composerD = registry.tryRegister(key) { fail() }
+            listOf(composerA, composerB, composerC, composerD).forEach { c ->
+                assertIs<IllegalStateException>(c.compose(NoScriptGenerationEnvironment).exceptionOrNull())
+            }
+        }
+
+        private fun <K> assertRegistryPropagatesComposerFailures(
+            key: K,
+            registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>,
+        ) {
+            val composer = registry.register(key) { increment() }
+            assertIs<Forwards>(registry[key])
+            registry.tryRegister(key) { Result.failure(IllegalStateException("oops")) }
+            assertIs<IllegalStateException>(composer.compose(NoScriptGenerationEnvironment).exceptionOrNull(),
+                "should have changed the inner object")
+        }
     }
 }
 

--- a/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
+++ b/azuki-script-generation/src/test/kotlin/com/anaplan/engineering/azuki/script/generation/CheckComposerTest.kt
@@ -16,7 +16,7 @@ class CheckComposerTest {
     }
 
     @Test
-    fun mapTryRegisterRemovesFromMapOnFailure() {
+    fun mapTryRegisterNullifiesOnFailure() {
         assertTryRegisterNullifiesOnFailure("a", makeMap())
     }
 
@@ -103,48 +103,51 @@ class CheckComposerTest {
         fun makeWrapper(): CheckComposerWrapper<NoScriptGenerationEnvironment, Example> =
             CheckComposerWrapper(Example.new("a"))
 
-        // These tests are identical for maps and wrappers, except for registry type and the key(s) in use:
+        // These tests are identical for maps and wrappers, except for registry type and the key(s) in use.
+        // Note that we could change most tests to take `registry.onKey(key)` directly, but then we'd lose the
+        // implicit exercising of assertions about `registry.onKey(key)`'s correctness.
 
         private fun <K> assertRegisterReusesSameComposer(
             keyIncrements: List<K>, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
         ) {
-            keyIncrements.forEach { registry.register(it) { increment() } }
+            keyIncrements.forEach { registry.onKey(it).register { increment() } }
 
             val keyCounts = keyIncrements.groupBy { it }.mapValues { it.value.size }
             assertEquals(keyCounts.size, registry.composers.size, "should only be as many composers as keys")
             keyCounts.forEach { (k, expected) ->
-                assertEquals(expected, registry[k]?.counter, "increments to $k should have been cumulative")
+                val actual = registry.onKey(k).composer?.counter
+                assertEquals(expected, actual, "increments to $k should have been cumulative")
             }
         }
 
         private fun <K> assertRegisterUpdatesRegistryOnObjectChange(
             key: K, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
         ) {
-            registry.register(key) { increment() }
-            assertIs<Forwards>(registry[key])
-            registry.register(key) { reverse() }
-            assertIs<Backwards>(registry[key])
+            registry.onKey(key).register { increment() }
+            assertIs<Forwards>(registry.onKey(key).composer)
+            registry.onKey(key).register { reverse() }
+            assertIs<Backwards>(registry.onKey(key).composer)
         }
 
         private fun <K> assertTryRegisterNullifiesOnFailure(
             key: K, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
         ) {
-            registry.register(key) { increment() }
-            assertIs<Forwards>(registry[key])
-            registry.tryRegister(key) { Result.failure(IllegalStateException("oops")) }
-            assertNull(registry[key], "the composer should now appear to have been removed")
+            registry.onKey(key).register { increment() }
+            assertIs<Forwards>(registry.onKey(key).composer)
+            registry.onKey(key).tryRegister { Result.failure(IllegalStateException("oops")) }
+            assertNull(registry.onKey(key).composer, "the composer should now appear to have been removed")
         }
 
         private fun <K> assertRegistryPropagatesComposerObjectChanges(
             key: K, registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>
         ) {
-            val composerA = registry.register(key) { increment() }
+            val composerA = registry.onKey(key).register { increment() }
             assertEquals("forwards(1)", composerA.toScript())
-            val composerB = registry.register(key) { reverse() }
+            val composerB = registry.onKey(key).register { reverse() }
             listOf(composerA, composerB).forEach { c -> assertEquals("backwards(0)", c.toScript()) }
-            val composerC = registry.register(key) { increment() }
+            val composerC = registry.onKey(key).register { increment() }
             listOf(composerA, composerB, composerC).forEach { c -> assertEquals("backwards(-1)", c.toScript()) }
-            val composerD = registry.tryRegister(key) { fail() }
+            val composerD = registry.onKey(key).tryRegister { fail() }
             listOf(composerA, composerB, composerC, composerD).forEach { c ->
                 assertIs<IllegalStateException>(c.compose(NoScriptGenerationEnvironment).exceptionOrNull())
             }
@@ -154,9 +157,9 @@ class CheckComposerTest {
             key: K,
             registry: CheckComposerRegistry<NoScriptGenerationEnvironment, K, Example>,
         ) {
-            val composer = registry.register(key) { increment() }
-            assertIs<Forwards>(registry[key])
-            registry.tryRegister(key) { Result.failure(IllegalStateException("oops")) }
+            val composer = registry.onKey(key).register { increment() }
+            assertIs<Forwards>(registry.onKey(key).composer)
+            registry.onKey(key).tryRegister { Result.failure(IllegalStateException("oops")) }
             assertIs<IllegalStateException>(composer.compose(NoScriptGenerationEnvironment).exceptionOrNull(),
                 "should have changed the inner object")
         }

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationCheckFactory.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationCheckFactory.kt
@@ -33,13 +33,13 @@ object GameScriptGenerationCheckFactory : GameCheckFactory {
     override fun hasToken(gameName: String, playerName: String, position: Position) = TicTacToeScriptGenerationCheck {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::boardHasToken, gameName, playerName, position)
     }.asComposable {
-        boardCheckState.hasToken(gameName, playerName, position)
+        boardCheckComposers.hasToken(gameName, playerName, position)
     }
 
     override fun hasSpace(gameName: String, position: Position) = TicTacToeScriptGenerationCheck {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::boardHasSpace, gameName, position)
     }.asComposable {
-        boardCheckState.hasSpace(gameName, position)
+        boardCheckComposers.hasSpace(gameName, position)
     }
 
     override fun hasState(gameName: String, moves: MoveMap) = TicTacToeScriptGenerationCheck {

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationCheckFactory.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerationCheckFactory.kt
@@ -27,16 +27,19 @@ object GameScriptGenerationCheckFactory : GameCheckFactory {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::gameHasPlayOrder, gameName, players)
     }
 
+    // These next two checks can be scriptified as functions, but also have 'composable' forms:
+    // if we have enough token and space checks to cover a board for a game, we can emit one check for the whole board.
+
     override fun hasToken(gameName: String, playerName: String, position: Position) = TicTacToeScriptGenerationCheck {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::boardHasToken, gameName, playerName, position)
     }.asComposable {
-        boardCheckStates.tryRegister(gameName) { hasToken(playerName, position) }
+        boardCheckState.hasToken(gameName, playerName, position)
     }
 
     override fun hasSpace(gameName: String, position: Position) = TicTacToeScriptGenerationCheck {
         TicTacToeScriptingHelper.scriptifyFunction(TicTacToeThen::boardHasSpace, gameName, position)
     }.asComposable {
-        boardCheckStates.tryRegister(gameName) { hasSpace(position) }
+        boardCheckState.hasSpace(gameName, position)
     }
 
     override fun hasState(gameName: String, moves: MoveMap) = TicTacToeScriptGenerationCheck {

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
@@ -13,10 +13,8 @@ val TicTacToeScriptGeneration = ScriptGenerationService.new(TicTacToeScriptGener
     ::TicTacToeDeclarationState).withEnvironmentFactory(::TicTacToeGenerationEnvironment)
     .withActionGeneratorFactory(TicTacToeScriptGenerationActionGeneratorFactory)
     .withQueryFactory(TicTacToeScriptGenerationQueryQueryFactory)
-    .withVerifyFactory(TicTacToeScriptGenerationVerificationQueryFactory)
-    .build()
+    .withVerifyFactory(TicTacToeScriptGenerationVerificationQueryFactory).build()
 
-// None of the declaration builders for TicTacToe use the environment:
 typealias TicTacToeScriptGenerationDeclarationBuilder<D> = ScriptGenerationDeclarationBuilder<TicTacToeGenerationEnvironment, D>
 typealias TicTacToeScriptGenerationDeclarationBuilderFactory<D> = ScriptGenerationDeclarationBuilderFactory<TicTacToeGenerationEnvironment, D>
 
@@ -33,11 +31,28 @@ val TicTacToeScriptingHelper = ScriptingHelper(mapOf(
 
 class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
 
-    // We want to collapse individual board-has-X checks into a single board-has-state check,
-    // but only if the entire board is covered by them.
-    val boardCheckStates = CheckComposerMap(::BoardCheckState)
+    val boardCheckState = BoardCheckState()
 
-    class BoardCheckState(private val gameName: String) : CheckComposer<TicTacToeGenerationEnvironment> {
+    /**
+     * Holds state for composing game board checks, keyed on game names.
+     *
+     * We want to collapse individual board-has-X checks into a single board-has-state check,
+     * but only if the entire board is covered by them.  The board check-state facilitates
+     * this by providing a registrar for composers for these checks.
+     */
+    class BoardCheckState :
+        CheckComposerRegistry<TicTacToeGenerationEnvironment, String, BoardCheckSubstate> by CheckComposerMap(::BoardCheckSubstate) {
+
+        fun hasToken(gameName: String, player: String, position: Position) =
+            tryRegister(gameName) { hasToken(player, position) }
+
+        fun hasSpace(gameName: String, position: Position) = tryRegister(gameName) { hasSpace(position) }
+    }
+
+    /**
+     * Holds state for composing board checks for one game.
+     */
+    class BoardCheckSubstate(private val gameName: String) : CheckComposer<TicTacToeGenerationEnvironment> {
 
         private val tokens = mutableMapOf<Position, String>()
         private val spaces = mutableSetOf<Position>()
@@ -53,7 +68,7 @@ class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
         fun hasToken(player: String, position: Position) = at(position) { tokens[position] = player }
         fun hasSpace(position: Position) = at(position) { spaces.add(position) }
 
-        private fun at(position: Position, fn: BoardCheckState.() -> Unit) =
+        private fun at(position: Position, fn: BoardCheckSubstate.() -> Unit) =
             if (position in tokens || position in spaces) {
                 failure(IllegalStateException("position $position is checked already"))
             } else success(apply(fn))
@@ -67,7 +82,5 @@ object TicTacToeRunnableScenarioClassGenerator : RunnableScenarioClassGenerator<
 /**
  * Default imports that should be added to any tic-tac-toe script (generated or parsed).
  */
-val ticTacToeStandardImports = arrayOf(
-    "com.anaplan.engineering.azuki.tictactoe.dsl.*",
-    "com.anaplan.engineering.azuki.tictactoe.*"
-)
+val ticTacToeStandardImports =
+    arrayOf("com.anaplan.engineering.azuki.tictactoe.dsl.*", "com.anaplan.engineering.azuki.tictactoe.*")

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
@@ -31,17 +31,17 @@ val TicTacToeScriptingHelper = ScriptingHelper(mapOf(
 
 class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
 
-    val boardCheckState = BoardCheckState()
+    val boardCheckComposers = BoardCheckComposerRegistry()
 
     /**
      * Holds state for composing game board checks, keyed on game names.
      *
      * We want to collapse individual board-has-X checks into a single board-has-state check,
-     * but only if the entire board is covered by them.  The board check-state facilitates
-     * this by providing a registrar for composers for these checks.
+     * but only if the entire board is covered by them.  This class allows this by storing
+     * composers for these checks.
      */
-    class BoardCheckState :
-        CheckComposerRegistry<TicTacToeGenerationEnvironment, String, BoardCheckSubstate> by CheckComposerMap(::BoardCheckSubstate) {
+    class BoardCheckComposerRegistry :
+        CheckComposerRegistry<TicTacToeGenerationEnvironment, String, BoardCheckComposer> by CheckComposerMap(::BoardCheckComposer) {
 
         fun hasToken(gameName: String, player: String, position: Position) =
             tryRegister(gameName) { hasToken(player, position) }
@@ -51,11 +51,15 @@ class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
 
     /**
      * Holds state for composing board checks for one game.
+     *
+     * Once all positions on a given game's board are fully specified, this composer can
+     * be composed into a single board check asserting all tokens and spaces.
      */
-    class BoardCheckSubstate(private val gameName: String) : CheckComposer<TicTacToeGenerationEnvironment> {
+    class BoardCheckComposer(private val gameName: String) : CheckComposer<TicTacToeGenerationEnvironment> {
 
         private val tokens = mutableMapOf<Position, String>()
         private val spaces = mutableSetOf<Position>()
+        private val isFullySpecified get() = tokens.size + spaces.size == Width * Height
 
         override fun compose(environment: TicTacToeGenerationEnvironment) = if (isFullySpecified) {
             success(listOf(GameScriptGenerationCheckFactory.hasState(gameName, tokens)))
@@ -63,12 +67,10 @@ class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
             failure(IllegalStateException("board has not been fully specified"))
         }
 
-        private val isFullySpecified get() = tokens.size + spaces.size == Width * Height
-
         fun hasToken(player: String, position: Position) = at(position) { tokens[position] = player }
         fun hasSpace(position: Position) = at(position) { spaces.add(position) }
 
-        private fun at(position: Position, fn: BoardCheckSubstate.() -> Unit) =
+        private fun at(position: Position, fn: BoardCheckComposer.() -> Unit) =
             if (position in tokens || position in spaces) {
                 failure(IllegalStateException("position $position is checked already"))
             } else success(apply(fn))

--- a/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
+++ b/tictactoe/adapter-script-generation/src/main/kotlin/com/anaplan/engineering/azuki/tictactoe/adapter/scriptgen/TicTacToeScriptGenerator.kt
@@ -44,9 +44,9 @@ class TicTacToeGenerationEnvironment : ScriptGenerationEnvironment {
         CheckComposerRegistry<TicTacToeGenerationEnvironment, String, BoardCheckComposer> by CheckComposerMap(::BoardCheckComposer) {
 
         fun hasToken(gameName: String, player: String, position: Position) =
-            tryRegister(gameName) { hasToken(player, position) }
+            onKey(gameName).tryRegister { hasToken(player, position) }
 
-        fun hasSpace(gameName: String, position: Position) = tryRegister(gameName) { hasSpace(position) }
+        fun hasSpace(gameName: String, position: Position) = onKey(gameName).tryRegister { hasSpace(position) }
     }
 
     /**


### PR DESCRIPTION
This PR creates a new `CheckComposerRegistry` interface and makes `CheckComposerMap` inherit from it.  This allows creating classes that act like composer registries (by delegating to `CheckComposerMap`) but add their own functionality.  Indeed, the motivation for this change is wanting to add methods to a composer map without having to patch them in with extension methods.

`TicTacToe` now exposes a new `BoardCheckComposerRegistry` class that serves as a somewhat contrived example of how this can be used.  (`BoardCheckState` is renamed to `BoardCheckComposer`.)