### PR TITLE
Use ByteArrayOutputStream on logs, and add a Lincheck test

### DIFF
--- a/azuki-core/build.gradle
+++ b/azuki-core/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation libs.kotlin.scripting.common
     implementation libs.kotlin.scripting.jvm
     implementation libs.kotlin.scripting.jvm.host
+
+    testImplementation libs.lincheck
 }
 
 publishing {

--- a/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
+++ b/azuki-core/src/main/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapper.kt
@@ -83,38 +83,41 @@ internal class TaskWrapper<
     }
 }
 
-private class LogAndCaptureOutputStream(
+internal class LogAndCaptureOutputStream(
     private val log: (String) -> Unit
 ) : OutputStream() {
-    private val capture = ByteArrayOutputStream()
-    private val buffer = mutableListOf<Byte>()
 
-    fun getCapturedText() = String(capture.toByteArray())
+    private val capture = ByteArrayOutputStream()
+    private val buffer = ByteArrayOutputStream()
+
+    fun getCapturedText(): String = capture.toString(Charsets.UTF_8)
 
     override fun write(b: Int) {
         if (b.toChar() == '\n') {
             logAndClearBuffer()
         } else {
-            buffer.add(b.toByte())
+            buffer.write(b)
         }
         capture.write(b)
     }
 
     override fun flush() {
+        buffer.flush()
         capture.flush()
     }
 
     override fun close() {
-        if (buffer.isNotEmpty()) {
+        if (buffer.size() != 0) {
             logAndClearBuffer()
         }
+        buffer.close()
         capture.close()
     }
 
     private fun logAndClearBuffer() {
         try {
-            log(String(buffer.toByteArray()))
-            buffer.clear()
+            log(buffer.toString(Charsets.UTF_8))
+            buffer.reset()
         } catch (e: Exception) {
             Log.warn("Unable to capture stdout for task: {}", e.message)
             Log.warn("Stacktrace:\n{}", e.stackTraceToString())

--- a/azuki-core/src/test/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapperTest.kt
+++ b/azuki-core/src/test/kotlin/com/anaplan/engineering/azuki/core/runner/TaskWrapperTest.kt
@@ -10,6 +10,8 @@ import com.anaplan.engineering.azuki.core.system.NoActionGeneratorFactory
 import com.anaplan.engineering.azuki.core.system.NoQueryFactory
 import com.anaplan.engineering.azuki.core.system.NoSystemDefaults
 import com.anaplan.engineering.azuki.core.system.SystemFactory
+import org.jetbrains.lincheck.Lincheck
+import java.io.ByteArrayOutputStream
 import kotlin.concurrent.thread
 import kotlin.test.*
 
@@ -37,7 +39,23 @@ class TaskWrapperTest {
         assertEquals("hello, world\n".repeat(10), result.log.error)
     }
 
-    // TODO: add concurrency tests here
+    @Test
+    fun logAndCaptureOutputStreamThreadSafety() = Lincheck.runConcurrentTest {
+        val out = ByteArrayOutputStream()
+
+        val os = LogAndCaptureOutputStream { out.write(it.toByteArray()) }
+
+        val w = thread { os.write("hello,\nworld".toByteArray()) }
+        val c1 = thread { os.close() }
+        val c2 = thread { os.close() }
+
+        w.join()
+        c1.join()
+        c2.join()
+
+        assertTrue("hello,world".startsWith(out.toString()));
+        assertTrue("hello,\nworld".startsWith(os.getCapturedText()));
+    }
 
     object DummyScenario : BuildableScenario<ActionFactory> {
         override fun declarations(actionFactory: ActionFactory) = listOf<Action>()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ guava = { group = "com.google.guava", name = "guava", version = "28.2-jre" }
 jna = { group = "net.java.dev.jna", name = "jna", version = "5.8.0" }
 
 mockk = { group = "io.mockk", name = "mockk", version = "1.10.2" }
+lincheck = { group = "org.jetbrains.lincheck", name = "lincheck", version = "3.2" }
 
 semver4j = { group = "org.semver4j", name = "semver4j", version = "5.2.2" }
 


### PR DESCRIPTION
This PR changes the `buffer` on `LogAndCaptureOutputStream` to use a `ByteArrayOutputStream` rather than a standard byte array.  This has pretty much the same effect as the latter, but is inherently `synchronized`, and should be more resilient to race conditions where the stream is double-`close`d or `close`d while something is trying to `write` to it.  (On paper, these situations shouldn't happen, but we've seen increasing amounts of unusual races here.)

Adds a Lincheck concurrency test for `LogAndCaptureOutputStream` to exercise what happens when something writes to it while two threads are trying to close it.  (I did experiment with Lincheck tests for `TaskWrapper`, but was unconvinced that they told me anything useful.)